### PR TITLE
feat: access to raw requests and responses (#45)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,5 +72,4 @@ jobs:
             test:turbo \
             --continue \
             --concurrency 1 \
-            ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && steps.zimic-setup.outputs.install-filters || '' }} \
-            -- --coverage
+            ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && steps.zimic-setup.outputs.install-filters || '' }}

--- a/apps/zimic-test-client/package.json
+++ b/apps/zimic-test-client/package.json
@@ -9,7 +9,7 @@
     "style:check": "pnpm style --check",
     "style:format": "pnpm style --write",
     "test": "dotenv -v NODE_ENV=test -- vitest",
-    "test:turbo": "pnpm run test run",
+    "test:turbo": "pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
     "deps:prepare": "pnpm deps:build && pnpm deps:install",
     "deps:build": "pnpm turbo build --filter zimic-test-client^...",

--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest';
+import { JSONValue } from 'zimic0';
 import type {
   DefaultBody,
   HttpInterceptor,
@@ -29,6 +30,7 @@ import type {
 
 describe('Exports', () => {
   it('should export all expected types', () => {
+    expectTypeOf<JSONValue>().not.toBeAny();
     expectTypeOf<DefaultBody>().not.toBeAny();
     expectTypeOf<HttpRequest>().not.toBeAny();
     expectTypeOf<HttpResponse>().not.toBeAny();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "turbo test:turbo",
     "types:check": "turbo types:check",
     "pre:commit": "lint-staged",
-    "pre:push": "pnpm style:check && turbo types:check lint:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 75% && turbo test:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 1 -- --coverage",
+    "pre:push": "pnpm style:check && turbo types:check lint:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 75% && turbo test:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 1",
     "prepare": "husky install || echo 'Could not install git hooks with husky.'"
   },
   "dependencies": {},

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -23,7 +23,7 @@
     "style:check": "pnpm style --check",
     "style:format": "pnpm style --write",
     "test": "dotenv -v NODE_ENV=test -- vitest",
-    "test:turbo": "pnpm run test run",
+    "test:turbo": "pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
     "deps:prepare": "pnpm deps:build && pnpm deps:install",
     "deps:build": "pnpm turbo build --filter @zimic/release^...",

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -76,7 +76,7 @@
     "style:check": "pnpm style --check",
     "style:format": "pnpm style --write",
     "test": "dotenv -v NODE_ENV=test -- vitest",
-    "test:turbo": "pnpm run test run",
+    "test:turbo": "pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
     "deps:prepare": "pnpm deps:build && pnpm deps:install",
     "deps:build": "pnpm turbo build --filter zimic^...",

--- a/packages/zimic/src/index.ts
+++ b/packages/zimic/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { JSONValue } from '@/types/json';

--- a/packages/zimic/src/interceptor/http/interceptor/InternalHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/InternalHttpInterceptor.ts
@@ -129,22 +129,22 @@ class InternalHttpInterceptor<Schema extends HttpInterceptorSchema, Worker exten
     path: Path,
     { request }: Context,
   ): Promise<HttpRequestHandlerResult> => {
-    const parsedRequest = await this._worker.parseRawRequest<Default<Schema[Path][Method]>>(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<Default<Schema[Path][Method]>>(request);
     const matchedTracker = this.findMatchedTracker(method, path, parsedRequest);
 
     if (matchedTracker) {
       const responseDeclaration = await matchedTracker.applyResponseDeclaration(parsedRequest);
 
-      const responseToParse = this._worker.createResponseFromDeclaration(responseDeclaration);
+      const responseToParse = HttpInterceptorWorker.createResponseFromDeclaration(responseDeclaration);
 
-      const parsedResponse = await this._worker.parseRawResponse<
+      const parsedResponse = await HttpInterceptorWorker.parseRawResponse<
         Default<Schema[Path][Method]>,
         typeof responseDeclaration.status
       >(responseToParse);
 
       matchedTracker.registerInterceptedRequest(parsedRequest, parsedResponse);
 
-      const responseToReturn = this._worker.createResponseFromDeclaration(responseDeclaration);
+      const responseToReturn = HttpInterceptorWorker.createResponseFromDeclaration(responseDeclaration);
       return { response: responseToReturn };
     } else {
       return { bypass: true };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -52,7 +52,7 @@ export function declareDeleteHttpInterceptorTests(
       const [deletionRequest] = deletionRequests;
       expect(deletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(deletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(deletionRequest.body).toEqualTypeOf<null>();
       expect(deletionRequest.body).toBe(null);
 
       expectTypeOf(deletionRequest.response.status).toEqualTypeOf<200>();
@@ -151,7 +151,7 @@ export function declareDeleteHttpInterceptorTests(
       const [genericDeletionRequest] = genericDeletionRequests;
       expect(genericDeletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericDeletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericDeletionRequest.body).toEqualTypeOf<null>();
       expect(genericDeletionRequest.body).toBe(null);
 
       expectTypeOf(genericDeletionRequest.response.status).toEqualTypeOf<200>();
@@ -181,7 +181,7 @@ export function declareDeleteHttpInterceptorTests(
       const [specificDeletionRequest] = specificDeletionRequests;
       expect(specificDeletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificDeletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificDeletionRequest.body).toEqualTypeOf<null>();
       expect(specificDeletionRequest.body).toBe(null);
 
       expectTypeOf(specificDeletionRequest.response.status).toEqualTypeOf<200>();
@@ -226,8 +226,7 @@ export function declareDeleteHttpInterceptorTests(
 
       let [deletionRequestWithoutResponse] = deletionRequestsWithoutResponse;
       expectTypeOf<typeof deletionRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof deletionRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof deletionRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof deletionRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       deletionPromise = fetch(`${baseURL}/users`, {
         method: 'DELETE',
@@ -239,8 +238,7 @@ export function declareDeleteHttpInterceptorTests(
 
       [deletionRequestWithoutResponse] = deletionRequestsWithoutResponse;
       expectTypeOf<typeof deletionRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof deletionRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof deletionRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof deletionRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const deletionTrackerWithResponse = deletionTrackerWithoutResponse.respond({
         status: 200,
@@ -317,7 +315,7 @@ export function declareDeleteHttpInterceptorTests(
       const [deletionRequest] = deletionRequests;
       expect(deletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(deletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(deletionRequest.body).toEqualTypeOf<null>();
       expect(deletionRequest.body).toBe(null);
 
       expectTypeOf(deletionRequest.response.status).toEqualTypeOf<200>();
@@ -346,7 +344,7 @@ export function declareDeleteHttpInterceptorTests(
       const [errorDeletionRequest] = errorDeletionRequests;
       expect(errorDeletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorDeletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorDeletionRequest.body).toEqualTypeOf<null>();
       expect(errorDeletionRequest.body).toBe(null);
 
       expectTypeOf(errorDeletionRequest.response.status).toEqualTypeOf<500>();
@@ -409,7 +407,7 @@ export function declareDeleteHttpInterceptorTests(
       let [deletionRequest] = deletionRequests;
       expect(deletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(deletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(deletionRequest.body).toEqualTypeOf<null>();
       expect(deletionRequest.body).toBe(null);
 
       expectTypeOf(deletionRequest.response.status).toEqualTypeOf<200>();
@@ -438,7 +436,7 @@ export function declareDeleteHttpInterceptorTests(
       const [errorDeletionRequest] = errorDeletionRequests;
       expect(errorDeletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorDeletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorDeletionRequest.body).toEqualTypeOf<null>();
       expect(errorDeletionRequest.body).toBe(null);
 
       expectTypeOf(errorDeletionRequest.response.status).toEqualTypeOf<500>();
@@ -461,7 +459,7 @@ export function declareDeleteHttpInterceptorTests(
       [deletionRequest] = deletionRequests;
       expect(deletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(deletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(deletionRequest.body).toEqualTypeOf<null>();
       expect(deletionRequest.body).toBe(null);
 
       expectTypeOf(deletionRequest.response.status).toEqualTypeOf<200>();
@@ -528,7 +526,7 @@ export function declareDeleteHttpInterceptorTests(
       const [deletionRequest] = deletionRequests;
       expect(deletionRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(deletionRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(deletionRequest.body).toEqualTypeOf<null>();
       expect(deletionRequest.body).toBe(null);
 
       expectTypeOf(deletionRequest.response.status).toEqualTypeOf<200>();

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -52,7 +52,7 @@ export function declareGetHttpInterceptorTests(
       const [listRequest] = listRequests;
       expect(listRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(listRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequest.body).toEqualTypeOf<null>();
       expect(listRequest.body).toBe(null);
 
       expectTypeOf(listRequest.response.status).toEqualTypeOf<200>();
@@ -98,7 +98,7 @@ export function declareGetHttpInterceptorTests(
       const [listRequest] = listRequests;
       expect(listRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(listRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequest.body).toEqualTypeOf<null>();
       expect(listRequest.body).toBe(null);
 
       expectTypeOf(listRequest.response.status).toEqualTypeOf<200>();
@@ -145,7 +145,7 @@ export function declareGetHttpInterceptorTests(
       const [genericGetRequest] = genericGetRequests;
       expect(genericGetRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericGetRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericGetRequest.body).toEqualTypeOf<null>();
       expect(genericGetRequest.body).toBe(null);
 
       expectTypeOf(genericGetRequest.response.status).toEqualTypeOf<200>();
@@ -175,7 +175,7 @@ export function declareGetHttpInterceptorTests(
       const [specificGetRequest] = specificGetRequests;
       expect(specificGetRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificGetRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificGetRequest.body).toEqualTypeOf<null>();
       expect(specificGetRequest.body).toBe(null);
 
       expectTypeOf(specificGetRequest.response.status).toEqualTypeOf<200>();
@@ -213,9 +213,8 @@ export function declareGetHttpInterceptorTests(
       expect(listRequestsWithoutResponse).toHaveLength(0);
 
       let [listRequestWithoutResponse] = listRequestsWithoutResponse;
-      expectTypeOf<typeof listRequestWithoutResponse.body>().toEqualTypeOf<never>();
-      expectTypeOf<typeof listRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof listRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof listRequestWithoutResponse.body>().toEqualTypeOf<null>();
+      expectTypeOf<typeof listRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       fetchPromise = fetch(`${baseURL}/users`, { method: 'GET' });
       await expect(fetchPromise).rejects.toThrowError();
@@ -223,9 +222,8 @@ export function declareGetHttpInterceptorTests(
       expect(listRequestsWithoutResponse).toHaveLength(0);
 
       [listRequestWithoutResponse] = listRequestsWithoutResponse;
-      expectTypeOf<typeof listRequestWithoutResponse.body>().toEqualTypeOf<never>();
-      expectTypeOf<typeof listRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof listRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof listRequestWithoutResponse.body>().toEqualTypeOf<null>();
+      expectTypeOf<typeof listRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const listTrackerWithResponse = listTrackerWithoutResponse.respond({
         status: 200,
@@ -246,7 +244,7 @@ export function declareGetHttpInterceptorTests(
       expect(listRequestWithResponse).toBeInstanceOf(Request);
       expect(listRequestWithResponse.response.status).toEqual(200);
 
-      expectTypeOf(listRequestWithResponse.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequestWithResponse.body).toEqualTypeOf<null>();
       expect(listRequestWithResponse.body).toBe(null);
 
       expectTypeOf(listRequestWithResponse.response.status).toEqualTypeOf<200>();
@@ -300,7 +298,7 @@ export function declareGetHttpInterceptorTests(
       const [listRequest] = listRequests;
       expect(listRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(listRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequest.body).toEqualTypeOf<null>();
       expect(listRequest.body).toBe(null);
 
       expectTypeOf(listRequest.response.status).toEqualTypeOf<200>();
@@ -329,7 +327,7 @@ export function declareGetHttpInterceptorTests(
       const [errorListRequest] = errorListRequests;
       expect(errorListRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorListRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorListRequest.body).toEqualTypeOf<null>();
       expect(errorListRequest.body).toBe(null);
 
       expectTypeOf(errorListRequest.response.status).toEqualTypeOf<500>();
@@ -392,7 +390,7 @@ export function declareGetHttpInterceptorTests(
       let [listRequest] = listRequests;
       expect(listRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(listRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequest.body).toEqualTypeOf<null>();
       expect(listRequest.body).toBe(null);
 
       expectTypeOf(listRequest.response.status).toEqualTypeOf<200>();
@@ -421,7 +419,7 @@ export function declareGetHttpInterceptorTests(
       const [errorListRequest] = errorListRequests;
       expect(errorListRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorListRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorListRequest.body).toEqualTypeOf<null>();
       expect(errorListRequest.body).toBe(null);
 
       expectTypeOf(errorListRequest.response.status).toEqualTypeOf<500>();
@@ -444,7 +442,7 @@ export function declareGetHttpInterceptorTests(
       [listRequest] = listRequests;
       expect(listRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(listRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequest.body).toEqualTypeOf<null>();
       expect(listRequest.body).toBe(null);
 
       expectTypeOf(listRequest.response.status).toEqualTypeOf<200>();
@@ -511,7 +509,7 @@ export function declareGetHttpInterceptorTests(
       const [listRequest] = listRequests;
       expect(listRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(listRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(listRequest.body).toEqualTypeOf<null>();
       expect(listRequest.body).toBe(null);
 
       expectTypeOf(listRequest.response.status).toEqualTypeOf<200>();

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -42,13 +42,13 @@ export function declareHeadHttpInterceptorTests(
       const [headRequest] = headRequests;
       expect(headRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequest.body).toEqualTypeOf<null>();
       expect(headRequest.body).toBe(null);
 
       expectTypeOf(headRequest.response.status).toEqualTypeOf<200>();
       expect(headRequest.response.status).toEqual(200);
 
-      expectTypeOf(headRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
     });
   });
@@ -82,7 +82,7 @@ export function declareHeadHttpInterceptorTests(
       const [headRequest] = headRequests;
       expect(headRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequest.body).toEqualTypeOf<null>();
       expect(headRequest.body).toBe(null);
 
       expectTypeOf(headRequest.response.status).toEqualTypeOf<200>();
@@ -91,7 +91,7 @@ export function declareHeadHttpInterceptorTests(
       expectTypeOf(headRequest.response.status).toEqualTypeOf<200>();
       expect(headRequest.response.status).toEqual(200);
 
-      expectTypeOf(headRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
     });
   });
@@ -125,13 +125,13 @@ export function declareHeadHttpInterceptorTests(
       const [genericHeadRequest] = genericHeadRequests;
       expect(genericHeadRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericHeadRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericHeadRequest.body).toEqualTypeOf<null>();
       expect(genericHeadRequest.body).toBe(null);
 
       expectTypeOf(genericHeadRequest.response.status).toEqualTypeOf<200>();
       expect(genericHeadRequest.response.status).toEqual(200);
 
-      expectTypeOf(genericHeadRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(genericHeadRequest.response.body).toEqualTypeOf<null>();
       expect(genericHeadRequest.response.body).toBe(null);
 
       genericHeadTracker.bypass();
@@ -151,13 +151,13 @@ export function declareHeadHttpInterceptorTests(
       const [specificHeadRequest] = specificHeadRequests;
       expect(specificHeadRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificHeadRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificHeadRequest.body).toEqualTypeOf<null>();
       expect(specificHeadRequest.body).toBe(null);
 
       expectTypeOf(specificHeadRequest.response.status).toEqualTypeOf<200>();
       expect(specificHeadRequest.response.status).toEqual(200);
 
-      expectTypeOf(specificHeadRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(specificHeadRequest.response.body).toEqualTypeOf<null>();
       expect(specificHeadRequest.response.body).toBe(null);
 
       const unmatchedHeadPromise = fetch(`${baseURL}/users/${2}`, { method: 'HEAD' });
@@ -189,9 +189,8 @@ export function declareHeadHttpInterceptorTests(
       expect(headRequestsWithoutResponse).toHaveLength(0);
 
       let [headRequestWithoutResponse] = headRequestsWithoutResponse;
-      expectTypeOf<typeof headRequestWithoutResponse.body>().toEqualTypeOf<never>();
-      expectTypeOf<typeof headRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof headRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof headRequestWithoutResponse.body>().toEqualTypeOf<null>();
+      expectTypeOf<typeof headRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       fetchPromise = fetch(`${baseURL}/users`, { method: 'HEAD' });
       await expect(fetchPromise).rejects.toThrowError();
@@ -199,9 +198,8 @@ export function declareHeadHttpInterceptorTests(
       expect(headRequestsWithoutResponse).toHaveLength(0);
 
       [headRequestWithoutResponse] = headRequestsWithoutResponse;
-      expectTypeOf<typeof headRequestWithoutResponse.body>().toEqualTypeOf<never>();
-      expectTypeOf<typeof headRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof headRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof headRequestWithoutResponse.body>().toEqualTypeOf<null>();
+      expectTypeOf<typeof headRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const headTrackerWithResponse = headTrackerWithoutResponse.respond({
         status: 200,
@@ -218,13 +216,13 @@ export function declareHeadHttpInterceptorTests(
       expect(headRequestWithResponse).toBeInstanceOf(Request);
       expect(headRequestWithResponse.response.status).toEqual(200);
 
-      expectTypeOf(headRequestWithResponse.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequestWithResponse.body).toEqualTypeOf<null>();
       expect(headRequestWithResponse.body).toBe(null);
 
       expectTypeOf(headRequestWithResponse.response.status).toEqualTypeOf<200>();
       expect(headRequestWithResponse.response.status).toEqual(200);
 
-      expectTypeOf(headRequestWithResponse.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequestWithResponse.response.body).toEqualTypeOf<null>();
       expect(headRequestWithResponse.response.body).toBe(null);
     });
   });
@@ -268,13 +266,13 @@ export function declareHeadHttpInterceptorTests(
       const [headRequest] = headRequests;
       expect(headRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequest.body).toEqualTypeOf<null>();
       expect(headRequest.body).toBe(null);
 
       expectTypeOf(headRequest.response.status).toEqualTypeOf<204>();
       expect(headRequest.response.status).toEqual(204);
 
-      expectTypeOf(headRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
 
       const errorHeadTracker = interceptor.head('/users').respond({
@@ -297,7 +295,7 @@ export function declareHeadHttpInterceptorTests(
       const [errorHeadRequest] = errorHeadRequests;
       expect(errorHeadRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorHeadRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorHeadRequest.body).toEqualTypeOf<null>();
       expect(errorHeadRequest.body).toBe(null);
 
       expectTypeOf(errorHeadRequest.response.status).toEqualTypeOf<500>();
@@ -356,16 +354,13 @@ export function declareHeadHttpInterceptorTests(
       let [headRequest] = headRequests;
       expect(headRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
-      expect(headRequest.body).toBe(null);
-
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequest.body).toEqualTypeOf<null>();
       expect(headRequest.body).toBe(null);
 
       expectTypeOf(headRequest.response.status).toEqualTypeOf<204>();
       expect(headRequest.response.status).toEqual(204);
 
-      expectTypeOf(headRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
 
       const errorHeadTracker = interceptor.head('/users').respond({
@@ -388,7 +383,7 @@ export function declareHeadHttpInterceptorTests(
       const [errorHeadRequest] = errorHeadRequests;
       expect(errorHeadRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorHeadRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorHeadRequest.body).toEqualTypeOf<null>();
       expect(errorHeadRequest.body).toBe(null);
 
       expectTypeOf(errorHeadRequest.response.status).toEqualTypeOf<500>();
@@ -408,16 +403,13 @@ export function declareHeadHttpInterceptorTests(
       [headRequest] = headRequests;
       expect(headRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
-      expect(headRequest.body).toBe(null);
-
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequest.body).toEqualTypeOf<null>();
       expect(headRequest.body).toBe(null);
 
       expectTypeOf(headRequest.response.status).toEqualTypeOf<204>();
       expect(headRequest.response.status).toEqual(204);
 
-      expectTypeOf(headRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
     });
   });
@@ -473,16 +465,13 @@ export function declareHeadHttpInterceptorTests(
       const [headRequest] = headRequests;
       expect(headRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
-      expect(headRequest.body).toBe(null);
-
-      expectTypeOf(headRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(headRequest.body).toEqualTypeOf<null>();
       expect(headRequest.body).toBe(null);
 
       expectTypeOf(headRequest.response.status).toEqualTypeOf<204>();
       expect(headRequest.response.status).toEqual(204);
 
-      expectTypeOf(headRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -46,13 +46,13 @@ export function declareOptionsHttpInterceptorTests(
       const [optionsRequest] = optionsRequests;
       expect(optionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(optionsRequest.body).toEqualTypeOf<null>();
       expect(optionsRequest.body).toBe(null);
 
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<200>();
       expect(optionsRequest.response.status).toEqual(200);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
     });
   });
@@ -105,7 +105,7 @@ export function declareOptionsHttpInterceptorTests(
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<200>();
       expect(optionsRequest.response.status).toEqual(200);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
     });
   });
@@ -139,13 +139,13 @@ export function declareOptionsHttpInterceptorTests(
       const [genericOptionsRequest] = genericOptionsRequests;
       expect(genericOptionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericOptionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericOptionsRequest.body).toEqualTypeOf<null>();
       expect(genericOptionsRequest.body).toBe(null);
 
       expectTypeOf(genericOptionsRequest.response.status).toEqualTypeOf<200>();
       expect(genericOptionsRequest.response.status).toEqual(200);
 
-      expectTypeOf(genericOptionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(genericOptionsRequest.response.body).toEqualTypeOf<null>();
       expect(genericOptionsRequest.response.body).toBe(null);
 
       genericOptionsTracker.bypass();
@@ -165,13 +165,13 @@ export function declareOptionsHttpInterceptorTests(
       const [specificOptionsRequest] = specificOptionsRequests;
       expect(specificOptionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificOptionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificOptionsRequest.body).toEqualTypeOf<null>();
       expect(specificOptionsRequest.body).toBe(null);
 
       expectTypeOf(specificOptionsRequest.response.status).toEqualTypeOf<200>();
       expect(specificOptionsRequest.response.status).toEqual(200);
 
-      expectTypeOf(specificOptionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(specificOptionsRequest.response.body).toEqualTypeOf<null>();
       expect(specificOptionsRequest.response.body).toBe(null);
 
       const unmatchedOptionsPromise = fetch(`${baseURL}/filters/${2}`, { method: 'OPTIONS' });
@@ -203,9 +203,8 @@ export function declareOptionsHttpInterceptorTests(
       expect(optionsRequestsWithoutResponse).toHaveLength(0);
 
       let [optionsRequestWithoutResponse] = optionsRequestsWithoutResponse;
-      expectTypeOf<typeof optionsRequestWithoutResponse.body>().toEqualTypeOf<never>();
-      expectTypeOf<typeof optionsRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof optionsRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof optionsRequestWithoutResponse.body>().toEqualTypeOf<null>();
+      expectTypeOf<typeof optionsRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       fetchPromise = fetch(`${baseURL}/filters`, { method: 'OPTIONS' });
       await expect(fetchPromise).rejects.toThrowError();
@@ -213,9 +212,8 @@ export function declareOptionsHttpInterceptorTests(
       expect(optionsRequestsWithoutResponse).toHaveLength(0);
 
       [optionsRequestWithoutResponse] = optionsRequestsWithoutResponse;
-      expectTypeOf<typeof optionsRequestWithoutResponse.body>().toEqualTypeOf<never>();
-      expectTypeOf<typeof optionsRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof optionsRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof optionsRequestWithoutResponse.body>().toEqualTypeOf<null>();
+      expectTypeOf<typeof optionsRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const optionsTrackerWithResponse = optionsTrackerWithoutResponse.respond({
         status: 200,
@@ -232,13 +230,13 @@ export function declareOptionsHttpInterceptorTests(
       expect(optionsRequestWithResponse).toBeInstanceOf(Request);
       expect(optionsRequestWithResponse.response.status).toEqual(200);
 
-      expectTypeOf(optionsRequestWithResponse.body).toEqualTypeOf<never>();
+      expectTypeOf(optionsRequestWithResponse.body).toEqualTypeOf<null>();
       expect(optionsRequestWithResponse.body).toBe(null);
 
       expectTypeOf(optionsRequestWithResponse.response.status).toEqualTypeOf<200>();
       expect(optionsRequestWithResponse.response.status).toEqual(200);
 
-      expectTypeOf(optionsRequestWithResponse.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequestWithResponse.response.body).toEqualTypeOf<null>();
       expect(optionsRequestWithResponse.response.body).toBe(null);
     });
   });
@@ -282,13 +280,13 @@ export function declareOptionsHttpInterceptorTests(
       const [optionsRequest] = optionsRequests;
       expect(optionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(optionsRequest.body).toEqualTypeOf<null>();
       expect(optionsRequest.body).toBe(null);
 
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<204>();
       expect(optionsRequest.response.status).toEqual(204);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
 
       const errorOptionsTracker = interceptor.options('/filters').respond({
@@ -311,7 +309,7 @@ export function declareOptionsHttpInterceptorTests(
       const [errorOptionsRequest] = errorOptionsRequests;
       expect(errorOptionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorOptionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorOptionsRequest.body).toEqualTypeOf<null>();
       expect(errorOptionsRequest.body).toBe(null);
 
       expectTypeOf(errorOptionsRequest.response.status).toEqualTypeOf<500>();
@@ -370,16 +368,13 @@ export function declareOptionsHttpInterceptorTests(
       let [optionsRequest] = optionsRequests;
       expect(optionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
-      expect(optionsRequest.body).toBe(null);
-
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(optionsRequest.body).toEqualTypeOf<null>();
       expect(optionsRequest.body).toBe(null);
 
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<204>();
       expect(optionsRequest.response.status).toEqual(204);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
 
       const errorOptionsTracker = interceptor.options('/filters').respond({
@@ -402,7 +397,7 @@ export function declareOptionsHttpInterceptorTests(
       const [errorOptionsRequest] = errorOptionsRequests;
       expect(errorOptionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorOptionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorOptionsRequest.body).toEqualTypeOf<null>();
       expect(errorOptionsRequest.body).toBe(null);
 
       expectTypeOf(errorOptionsRequest.response.status).toEqualTypeOf<500>();
@@ -422,16 +417,13 @@ export function declareOptionsHttpInterceptorTests(
       [optionsRequest] = optionsRequests;
       expect(optionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
-      expect(optionsRequest.body).toBe(null);
-
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(optionsRequest.body).toEqualTypeOf<null>();
       expect(optionsRequest.body).toBe(null);
 
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<204>();
       expect(optionsRequest.response.status).toEqual(204);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
     });
   });
@@ -487,16 +479,13 @@ export function declareOptionsHttpInterceptorTests(
       const [optionsRequest] = optionsRequests;
       expect(optionsRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
-      expect(optionsRequest.body).toBe(null);
-
-      expectTypeOf(optionsRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(optionsRequest.body).toEqualTypeOf<null>();
       expect(optionsRequest.body).toBe(null);
 
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<204>();
       expect(optionsRequest.response.status).toEqual(204);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<unknown>();
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -52,7 +52,7 @@ export function declarePatchHttpInterceptorTests(
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -152,7 +152,7 @@ export function declarePatchHttpInterceptorTests(
       const [genericUpdateRequest] = genericUpdateRequests;
       expect(genericUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericUpdateRequest.body).toEqualTypeOf<null>();
       expect(genericUpdateRequest.body).toBe(null);
 
       expectTypeOf(genericUpdateRequest.response.status).toEqualTypeOf<200>();
@@ -182,7 +182,7 @@ export function declarePatchHttpInterceptorTests(
       const [specificUpdateRequest] = specificUpdateRequests;
       expect(specificUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificUpdateRequest.body).toEqualTypeOf<null>();
       expect(specificUpdateRequest.body).toBe(null);
 
       expectTypeOf(specificUpdateRequest.response.status).toEqualTypeOf<200>();
@@ -227,8 +227,7 @@ export function declarePatchHttpInterceptorTests(
 
       let [updateRequestWithoutResponse] = updateRequestsWithoutResponse;
       expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       updatePromise = fetch(`${baseURL}/users`, {
         method: 'PATCH',
@@ -240,8 +239,7 @@ export function declarePatchHttpInterceptorTests(
 
       [updateRequestWithoutResponse] = updateRequestsWithoutResponse;
       expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const updateTrackerWithResponse = updateTrackerWithoutResponse.respond({
         status: 200,
@@ -318,7 +316,7 @@ export function declarePatchHttpInterceptorTests(
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -347,7 +345,7 @@ export function declarePatchHttpInterceptorTests(
       const [errorUpdateRequest] = errorUpdateRequests;
       expect(errorUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<null>();
       expect(errorUpdateRequest.body).toBe(null);
 
       expectTypeOf(errorUpdateRequest.response.status).toEqualTypeOf<500>();
@@ -410,7 +408,7 @@ export function declarePatchHttpInterceptorTests(
       let [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -439,7 +437,7 @@ export function declarePatchHttpInterceptorTests(
       const [errorUpdateRequest] = errorUpdateRequests;
       expect(errorUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<null>();
       expect(errorUpdateRequest.body).toBe(null);
 
       expectTypeOf(errorUpdateRequest.response.status).toEqualTypeOf<500>();
@@ -462,7 +460,7 @@ export function declarePatchHttpInterceptorTests(
       [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -529,7 +527,7 @@ export function declarePatchHttpInterceptorTests(
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -52,7 +52,7 @@ export function declarePostHttpInterceptorTests(
       const [creationRequest] = creationRequests;
       expect(creationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(creationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(creationRequest.body).toEqualTypeOf<null>();
       expect(creationRequest.body).toBe(null);
 
       expectTypeOf(creationRequest.response.status).toEqualTypeOf<201>();
@@ -152,7 +152,7 @@ export function declarePostHttpInterceptorTests(
       const [genericCreationRequest] = genericCreationRequests;
       expect(genericCreationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericCreationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericCreationRequest.body).toEqualTypeOf<null>();
       expect(genericCreationRequest.body).toBe(null);
 
       expectTypeOf(genericCreationRequest.response.status).toEqualTypeOf<201>();
@@ -182,7 +182,7 @@ export function declarePostHttpInterceptorTests(
       const [specificCreationRequest] = specificCreationRequests;
       expect(specificCreationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificCreationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificCreationRequest.body).toEqualTypeOf<null>();
       expect(specificCreationRequest.body).toBe(null);
 
       expectTypeOf(specificCreationRequest.response.status).toEqualTypeOf<201>();
@@ -227,8 +227,7 @@ export function declarePostHttpInterceptorTests(
 
       let [creationRequestWithoutResponse] = creationRequestsWithoutResponse;
       expectTypeOf<typeof creationRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof creationRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof creationRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof creationRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       creationPromise = fetch(`${baseURL}/users`, {
         method: 'POST',
@@ -240,8 +239,7 @@ export function declarePostHttpInterceptorTests(
 
       [creationRequestWithoutResponse] = creationRequestsWithoutResponse;
       expectTypeOf<typeof creationRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof creationRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof creationRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof creationRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const creationTrackerWithResponse = creationTrackerWithoutResponse.respond({
         status: 201,
@@ -323,7 +321,7 @@ export function declarePostHttpInterceptorTests(
       const [creationRequest] = creationRequests;
       expect(creationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(creationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(creationRequest.body).toEqualTypeOf<null>();
       expect(creationRequest.body).toBe(null);
 
       expectTypeOf(creationRequest.response.status).toEqualTypeOf<201>();
@@ -352,7 +350,7 @@ export function declarePostHttpInterceptorTests(
       const [errorCreationRequest] = errorCreationRequests;
       expect(errorCreationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorCreationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorCreationRequest.body).toEqualTypeOf<null>();
       expect(errorCreationRequest.body).toBe(null);
 
       expectTypeOf(errorCreationRequest.response.status).toEqualTypeOf<500>();
@@ -415,7 +413,7 @@ export function declarePostHttpInterceptorTests(
       let [creationRequest] = creationRequests;
       expect(creationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(creationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(creationRequest.body).toEqualTypeOf<null>();
       expect(creationRequest.body).toBe(null);
 
       expectTypeOf(creationRequest.response.status).toEqualTypeOf<201>();
@@ -444,7 +442,7 @@ export function declarePostHttpInterceptorTests(
       const [errorCreationRequest] = errorCreationRequests;
       expect(errorCreationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorCreationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorCreationRequest.body).toEqualTypeOf<null>();
       expect(errorCreationRequest.body).toBe(null);
 
       expectTypeOf(errorCreationRequest.response.status).toEqualTypeOf<500>();
@@ -467,7 +465,7 @@ export function declarePostHttpInterceptorTests(
       [creationRequest] = creationRequests;
       expect(creationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(creationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(creationRequest.body).toEqualTypeOf<null>();
       expect(creationRequest.body).toBe(null);
 
       expectTypeOf(creationRequest.response.status).toEqualTypeOf<201>();
@@ -534,7 +532,7 @@ export function declarePostHttpInterceptorTests(
       const [creationRequest] = creationRequests;
       expect(creationRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(creationRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(creationRequest.body).toEqualTypeOf<null>();
       expect(creationRequest.body).toBe(null);
 
       expectTypeOf(creationRequest.response.status).toEqualTypeOf<201>();

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -52,7 +52,7 @@ export function declarePutHttpInterceptorTests(
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -152,7 +152,7 @@ export function declarePutHttpInterceptorTests(
       const [genericUpdateRequest] = genericUpdateRequests;
       expect(genericUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(genericUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(genericUpdateRequest.body).toEqualTypeOf<null>();
       expect(genericUpdateRequest.body).toBe(null);
 
       expectTypeOf(genericUpdateRequest.response.status).toEqualTypeOf<200>();
@@ -182,7 +182,7 @@ export function declarePutHttpInterceptorTests(
       const [specificUpdateRequest] = specificUpdateRequests;
       expect(specificUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(specificUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(specificUpdateRequest.body).toEqualTypeOf<null>();
       expect(specificUpdateRequest.body).toBe(null);
 
       expectTypeOf(specificUpdateRequest.response.status).toEqualTypeOf<200>();
@@ -227,8 +227,7 @@ export function declarePutHttpInterceptorTests(
 
       let [updateRequestWithoutResponse] = updateRequestsWithoutResponse;
       expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       updatePromise = fetch(`${baseURL}/users`, {
         method: 'PUT',
@@ -240,8 +239,7 @@ export function declarePutHttpInterceptorTests(
 
       [updateRequestWithoutResponse] = updateRequestsWithoutResponse;
       expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.status>().toEqualTypeOf<never>();
-      expectTypeOf<typeof updateRequestWithoutResponse.response.body>().toEqualTypeOf<never>();
+      expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const updateTrackerWithResponse = updateTrackerWithoutResponse.respond({
         status: 200,
@@ -318,7 +316,7 @@ export function declarePutHttpInterceptorTests(
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -347,7 +345,7 @@ export function declarePutHttpInterceptorTests(
       const [errorUpdateRequest] = errorUpdateRequests;
       expect(errorUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<null>();
       expect(errorUpdateRequest.body).toBe(null);
 
       expectTypeOf(errorUpdateRequest.response.status).toEqualTypeOf<500>();
@@ -410,7 +408,7 @@ export function declarePutHttpInterceptorTests(
       let [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -439,7 +437,7 @@ export function declarePutHttpInterceptorTests(
       const [errorUpdateRequest] = errorUpdateRequests;
       expect(errorUpdateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(errorUpdateRequest.body).toEqualTypeOf<null>();
       expect(errorUpdateRequest.body).toBe(null);
 
       expectTypeOf(errorUpdateRequest.response.status).toEqualTypeOf<500>();
@@ -462,7 +460,7 @@ export function declarePutHttpInterceptorTests(
       [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
@@ -529,7 +527,7 @@ export function declarePutHttpInterceptorTests(
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<never>();
+      expectTypeOf(updateRequest.body).toEqualTypeOf<null>();
       expect(updateRequest.body).toBe(null);
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, it } from 'vitest';
+import { expect, expectTypeOf, it } from 'vitest';
 
 import { HttpInterceptorOptions } from '../../types/options';
 import { HttpInterceptor } from '../../types/public';
@@ -216,6 +216,14 @@ export function declareTypeHttpInterceptorTests(
     interceptor.post('/notifications/read').respond({
       status: 204,
     });
+    interceptor.post('/notifications/read').respond({
+      status: 204,
+      body: null,
+    });
+    interceptor.post('/notifications/read').respond({
+      status: 204,
+      body: undefined,
+    });
 
     interceptor.get('/users').respond({
       status: 200,
@@ -340,7 +348,8 @@ export function declareTypeHttpInterceptorTests(
     expectTypeOf<UserCreationResponseBody>().toEqualTypeOf<User>();
 
     const userListTracker = interceptor.get('/users').respond((request) => {
-      expectTypeOf(request.body).toEqualTypeOf<never>();
+      expectTypeOf(request.body).toEqualTypeOf<null>();
+      expect(request.body).toBe(null);
 
       return {
         status: 200,
@@ -351,13 +360,14 @@ export function declareTypeHttpInterceptorTests(
     const userListRequests = userListTracker.requests();
 
     type UserListRequestBody = (typeof userListRequests)[number]['body'];
-    expectTypeOf<UserListRequestBody>().toEqualTypeOf<never>();
+    expectTypeOf<UserListRequestBody>().toEqualTypeOf<null>();
 
     type UserListResponseBody = (typeof userListRequests)[number]['response']['body'];
     expectTypeOf<UserListResponseBody>().toEqualTypeOf<User[]>();
 
     const groupGetTracker = interceptor.get<'/groups/:id'>(`/groups/${1}`).respond((request) => {
-      expectTypeOf(request.body).toEqualTypeOf<never>();
+      expectTypeOf(request.body).toEqualTypeOf<null>();
+      expect(request.body).toBe(null);
 
       return {
         status: 200,
@@ -368,7 +378,7 @@ export function declareTypeHttpInterceptorTests(
     const groupGetRequests = groupGetTracker.requests();
 
     type GroupGetRequestBody = (typeof groupGetRequests)[number]['body'];
-    expectTypeOf<GroupGetRequestBody>().toEqualTypeOf<never>();
+    expectTypeOf<GroupGetRequestBody>().toEqualTypeOf<null>();
 
     type GroupGetResponseBody = (typeof groupGetRequests)[number]['response']['body'];
     expectTypeOf<GroupGetResponseBody>().toEqualTypeOf<{ users: User[] }>();

--- a/packages/zimic/src/interceptor/http/requestTracker/InternalHttpRequestTracker.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/InternalHttpRequestTracker.ts
@@ -91,7 +91,7 @@ class InternalHttpRequestTracker<
     return new Proxy(request as unknown as TrackedHttpInterceptorRequest<MethodSchema, StatusCode>, {
       get(target, property) {
         if (property === 'response') {
-          return response satisfies TrackedHttpInterceptorRequest<MethodSchema, StatusCode>['response'];
+          return response satisfies HttpInterceptorResponse<MethodSchema, StatusCode>;
         }
         return Reflect.get(target, property, target) as unknown;
       },

--- a/packages/zimic/src/interceptor/http/requestTracker/__tests__/InternalHttpRequestTracker.test.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/__tests__/InternalHttpRequestTracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
-import { HttpInterceptorMethodSchema } from '../../interceptor/types/schema';
+import { HttpInterceptorSchema } from '../../interceptor/types/schema';
 import HttpInterceptorWorker from '../../interceptorWorker/HttpInterceptorWorker';
 import { HttpRequest, HttpResponse } from '../../interceptorWorker/types';
 import NoResponseDefinitionError from '../errors/NoResponseDefinitionError';
@@ -15,30 +15,41 @@ import {
 describe('InternalHttpRequestTracker', () => {
   const defaultBaseURL = 'http://localhost:3000';
 
+  type MethodSchema = HttpInterceptorSchema.Method<{
+    request: {
+      body: { success?: undefined };
+    };
+    response: {
+      200: {
+        body: { success: true };
+      };
+    };
+  }>;
+
   it('should not match any request if contains no declared response', async () => {
-    const tracker = new InternalHttpRequestTracker();
+    const tracker = new InternalHttpRequestTracker<MethodSchema>();
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
     expect(tracker.matchesRequest(parsedRequest)).toBe(false);
   });
 
   it('should match any request if contains declared response', async () => {
-    const tracker = new InternalHttpRequestTracker().respond({
+    const tracker = new InternalHttpRequestTracker<MethodSchema>().respond({
       status: 200,
-      body: {},
+      body: { success: true },
     });
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
     expect(tracker.matchesRequest(parsedRequest)).toBe(true);
   });
 
   it('should not match any request if bypassed', async () => {
-    const tracker = new InternalHttpRequestTracker();
+    const tracker = new InternalHttpRequestTracker<MethodSchema>();
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
     expect(tracker.matchesRequest(parsedRequest)).toBe(false);
 
     tracker.bypass();
@@ -46,7 +57,7 @@ describe('InternalHttpRequestTracker', () => {
 
     tracker.respond({
       status: 200,
-      body: {},
+      body: { success: true },
     });
     expect(tracker.matchesRequest(parsedRequest)).toBe(true);
 
@@ -55,16 +66,16 @@ describe('InternalHttpRequestTracker', () => {
   });
 
   it('should create response with declared status and body', async () => {
-    const responseStatus = 201;
-    const responseBody = { success: true };
+    const responseStatus = 200;
+    const responseBody = { success: true } as const;
 
-    const tracker = new InternalHttpRequestTracker().respond({
+    const tracker = new InternalHttpRequestTracker<MethodSchema>().respond({
       status: responseStatus,
       body: responseBody,
     });
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
     const response = await tracker.applyResponseDeclaration(parsedRequest);
 
     expect(response.status).toBe(responseStatus);
@@ -72,22 +83,22 @@ describe('InternalHttpRequestTracker', () => {
   });
 
   it('should create response with declared status and body factory', async () => {
-    const responseStatus = 201;
-    const responseBody = { success: true };
+    const responseStatus = 200;
+    const responseBody = { success: true } as const;
 
     const responseFactory = vi.fn<
-      [HttpInterceptorRequest<HttpInterceptorMethodSchema>],
-      HttpRequestTrackerResponseDeclaration<HttpInterceptorMethodSchema, number>
+      [HttpInterceptorRequest<MethodSchema>],
+      HttpRequestTrackerResponseDeclaration<MethodSchema, 200>
     >(() => ({
       status: responseStatus,
       body: responseBody,
     }));
 
-    const tracker = new InternalHttpRequestTracker();
+    const tracker = new InternalHttpRequestTracker<MethodSchema>();
     tracker.respond(responseFactory);
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
     const response = await tracker.applyResponseDeclaration(parsedRequest);
 
     expect(response.status).toBe(responseStatus);
@@ -98,10 +109,10 @@ describe('InternalHttpRequestTracker', () => {
   });
 
   it('should throw an error if trying to create a response without a declared response', async () => {
-    const tracker = new InternalHttpRequestTracker();
+    const tracker = new InternalHttpRequestTracker<MethodSchema>();
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
     await expect(async () => {
       await tracker.applyResponseDeclaration(parsedRequest);
@@ -109,21 +120,19 @@ describe('InternalHttpRequestTracker', () => {
   });
 
   it('should keep track of the intercepted requests and responses', async () => {
-    const tracker = new InternalHttpRequestTracker().respond({
+    const tracker = new InternalHttpRequestTracker<MethodSchema>().respond({
       status: 200,
-      body: {},
+      body: { success: true },
     });
 
     const firstRequest = new Request(defaultBaseURL);
-    const parsedFirstRequest = await HttpInterceptorWorker.parseRawRequest(firstRequest);
+    const parsedFirstRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(firstRequest);
 
     const firstResponseDeclaration = await tracker.applyResponseDeclaration(parsedFirstRequest);
     const firstResponse = Response.json(firstResponseDeclaration.body, {
       status: firstResponseDeclaration.status,
     });
-    const parsedFirstResponse = await HttpInterceptorWorker.parseRawResponse<HttpInterceptorMethodSchema, 200>(
-      firstResponse,
-    );
+    const parsedFirstResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(firstResponse);
 
     tracker.registerInterceptedRequest(parsedFirstRequest, parsedFirstResponse);
 
@@ -134,15 +143,13 @@ describe('InternalHttpRequestTracker', () => {
     expect(interceptedRequests[0].response).toEqual(firstResponse);
 
     const secondRequest = new Request(`${defaultBaseURL}/path`);
-    const parsedSecondRequest = await HttpInterceptorWorker.parseRawRequest(secondRequest);
+    const parsedSecondRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(secondRequest);
     const secondResponseDeclaration = await tracker.applyResponseDeclaration(parsedSecondRequest);
 
     const secondResponse = Response.json(secondResponseDeclaration.body, {
       status: secondResponseDeclaration.status,
     });
-    const parsedSecondResponse = await HttpInterceptorWorker.parseRawResponse<HttpInterceptorMethodSchema, 200>(
-      secondResponse,
-    );
+    const parsedSecondResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(secondResponse);
 
     tracker.registerInterceptedRequest(parsedSecondRequest, parsedSecondResponse);
 
@@ -156,20 +163,20 @@ describe('InternalHttpRequestTracker', () => {
   });
 
   it('should provide access to the raw intercepted requests and responses', async () => {
-    const tracker = new InternalHttpRequestTracker().respond({
+    const tracker = new InternalHttpRequestTracker<MethodSchema>().respond({
       status: 200,
-      body: { response: true },
+      body: { success: true },
     });
 
     const request = new Request(defaultBaseURL, {
       method: 'POST',
-      body: JSON.stringify({ request: true }),
+      body: JSON.stringify({ success: undefined } satisfies MethodSchema['request']['body']),
     });
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
     const responseDeclaration = await tracker.applyResponseDeclaration(parsedRequest);
     const response = Response.json(responseDeclaration.body, { status: responseDeclaration.status });
-    const parsedResponse = await HttpInterceptorWorker.parseRawResponse<HttpInterceptorMethodSchema, 200>(response);
+    const parsedResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
 
     tracker.registerInterceptedRequest(parsedRequest, parsedResponse);
 
@@ -178,34 +185,38 @@ describe('InternalHttpRequestTracker', () => {
 
     expect(interceptedRequests[0]).toEqual(parsedRequest);
 
-    expectTypeOf(interceptedRequests[0].raw).toEqualTypeOf<HttpRequest>();
+    expectTypeOf(interceptedRequests[0].raw).toEqualTypeOf<HttpRequest<{ success?: undefined }>>();
     expect(interceptedRequests[0].raw).toBeInstanceOf(Request);
     expect(interceptedRequests[0].raw.url).toBe(`${defaultBaseURL}/`);
     expect(interceptedRequests[0].raw.method).toBe('POST');
     expect(interceptedRequests[0].raw.headers).toEqual(request.headers);
-    expect(await interceptedRequests[0].raw.json()).toEqual({ request: true });
+    expectTypeOf(interceptedRequests[0].raw.json).toEqualTypeOf<() => Promise<{ success?: undefined }>>();
+    expect(await interceptedRequests[0].raw.json()).toEqual<MethodSchema['request']['body']>({ success: undefined });
 
     expect(interceptedRequests[0].response).toEqual(parsedResponse);
 
-    expectTypeOf(interceptedRequests[0].response.raw).toEqualTypeOf<HttpResponse>();
+    expectTypeOf(interceptedRequests[0].response.raw).toEqualTypeOf<HttpResponse<{ success: true }, 200>>();
     expect(interceptedRequests[0].response.raw).toBeInstanceOf(Response);
     expect(interceptedRequests[0].response.raw.status).toBe(200);
     expect(interceptedRequests[0].response.raw.headers).toEqual(response.headers);
-    expect(await interceptedRequests[0].response.raw.json()).toEqual({ response: true });
+    expectTypeOf(interceptedRequests[0].response.raw.json).toEqualTypeOf<() => Promise<{ success: true }>>();
+    expect(await interceptedRequests[0].response.raw.json()).toEqual<MethodSchema['response'][200]['body']>({
+      success: true,
+    });
   });
 
   it('should provide no access to hidden properties in raw intercepted requests and responses', async () => {
-    const tracker = new InternalHttpRequestTracker().respond({
+    const tracker = new InternalHttpRequestTracker<MethodSchema>().respond({
       status: 200,
-      body: {},
+      body: { success: true },
     });
 
     const request = new Request(defaultBaseURL);
-    const parsedRequest = await HttpInterceptorWorker.parseRawRequest(request);
+    const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
     const responseDeclaration = await tracker.applyResponseDeclaration(parsedRequest);
     const response = Response.json(responseDeclaration.body, { status: responseDeclaration.status });
-    const parsedResponse = await HttpInterceptorWorker.parseRawResponse<HttpInterceptorMethodSchema, 200>(response);
+    const parsedResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
 
     tracker.registerInterceptedRequest(parsedRequest, parsedResponse);
 

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -11,7 +11,7 @@ export type HttpRequestTrackerResponseAttribute<
   ResponseSchema extends HttpInterceptorResponseSchema,
   AttributeName extends keyof ResponseSchema,
 > = undefined | void extends ResponseSchema[AttributeName]
-  ? { [Name in AttributeName]?: never }
+  ? { [Name in AttributeName]?: null }
   : { [Name in AttributeName]: ResponseSchema[AttributeName] };
 
 export type HttpRequestTrackerResponseDeclaration<
@@ -30,7 +30,7 @@ export type HttpRequestTrackerResponseDeclarationFactory<
 
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body> {
-  body: Default<MethodSchema['request']>['body'];
+  body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
   raw: HttpResponse<Default<MethodSchema['request']>['body']>;
 }
 
@@ -39,7 +39,7 @@ export interface HttpInterceptorResponse<
   StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > extends Omit<HttpResponse, keyof Body> {
   status: StatusCode;
-  body: Default<MethodSchema['response']>[StatusCode]['body'];
+  body: Default<Default<MethodSchema['response']>[StatusCode]['body'], null>;
   raw: HttpResponse<Default<MethodSchema['response']>[StatusCode]['body']>;
 }
 
@@ -56,5 +56,5 @@ export interface TrackedHttpInterceptorRequest<
   MethodSchema extends HttpInterceptorMethodSchema,
   StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<MethodSchema['response']>> = never,
 > extends HttpInterceptorRequest<MethodSchema> {
-  response: HttpInterceptorResponse<MethodSchema, StatusCode>;
+  response: StatusCode extends [never] ? never : HttpInterceptorResponse<MethodSchema, StatusCode>;
 }

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -30,9 +30,8 @@ export type HttpRequestTrackerResponseDeclarationFactory<
 
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body> {
-  body: undefined | void extends Default<MethodSchema['request']>['body']
-    ? never
-    : Default<MethodSchema['request']>['body'];
+  body: Default<MethodSchema['request']>['body'];
+  raw: HttpResponse<Default<MethodSchema['request']>['body']>;
 }
 
 export interface HttpInterceptorResponse<
@@ -41,7 +40,17 @@ export interface HttpInterceptorResponse<
 > extends Omit<HttpResponse, keyof Body> {
   status: StatusCode;
   body: Default<MethodSchema['response']>[StatusCode]['body'];
+  raw: HttpResponse<Default<MethodSchema['response']>[StatusCode]['body']>;
 }
+
+export const HTTP_INTERCEPTOR_REQUEST_HIDDEN_BODY_PROPERTIES = new Set<
+  Exclude<keyof Body, keyof HttpInterceptorRequest<never>>
+>(['bodyUsed', 'arrayBuffer', 'blob', 'formData', 'json', 'text']);
+
+export const HTTP_INTERCEPTOR_RESPONSE_HIDDEN_BODY_PROPERTIES =
+  HTTP_INTERCEPTOR_REQUEST_HIDDEN_BODY_PROPERTIES satisfies Set<
+    Exclude<keyof Body, keyof HttpInterceptorResponse<never, never>>
+  >;
 
 export interface TrackedHttpInterceptorRequest<
   MethodSchema extends HttpInterceptorMethodSchema,

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -31,7 +31,7 @@ export type HttpRequestTrackerResponseDeclarationFactory<
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body> {
   body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
-  raw: HttpResponse<Default<MethodSchema['request']>['body']>;
+  raw: HttpRequest<Default<MethodSchema['request']>['body']>;
 }
 
 export interface HttpInterceptorResponse<

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -31,7 +31,7 @@ export type HttpRequestTrackerResponseDeclarationFactory<
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body> {
   body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
-  raw: HttpRequest<Default<MethodSchema['request']>['body']>;
+  raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;
 }
 
 export interface HttpInterceptorResponse<
@@ -40,7 +40,7 @@ export interface HttpInterceptorResponse<
 > extends Omit<HttpResponse, keyof Body> {
   status: StatusCode;
   body: Default<Default<MethodSchema['response']>[StatusCode]['body'], null>;
-  raw: HttpResponse<Default<MethodSchema['response']>[StatusCode]['body']>;
+  raw: HttpResponse<Default<Default<MethodSchema['response']>[StatusCode]['body'], null>, StatusCode>;
 }
 
 export const HTTP_INTERCEPTOR_REQUEST_HIDDEN_BODY_PROPERTIES = new Set<

--- a/packages/zimic/src/types/utils.ts
+++ b/packages/zimic/src/types/utils.ts
@@ -1,6 +1,8 @@
-export type Default<Type, IfUndefined = never> = undefined | void extends Type
-  ? IfUndefined
-  : Exclude<Type, undefined | void>;
+export type Default<Type, IfEmpty = never> = undefined extends Type
+  ? IfEmpty
+  : void extends Type
+    ? IfEmpty
+    : Exclude<Type, undefined | void>;
 
 export type PossiblePromise<Type> = Type | Promise<Type>;
 


### PR DESCRIPTION
- feat(#zimic): support accessing raw requests and responses
- fix(#zimic): improve request and response types to follow spec
- test(#zimic): verify access to raw requests and responses
- feat(#zimic): export `JSONValue` from root index
- fix(#zimic): consider default null body in raw requests and responses
- test(zimic-test-client): verify request and resposne types
- fix: move coverage to each test:turbo to reuse cache

Closes #45.
