### PR TITLE
perf: remove worker handlers after an interceptor is cleared (#57)

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/InternalHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/InternalHttpInterceptor.ts
@@ -103,7 +103,7 @@ class InternalHttpInterceptor<Schema extends HttpInterceptorSchema> implements H
 
       const pathWithBaseURL = this.applyBaseURL(tracker.path());
 
-      this.worker.use(tracker.method(), pathWithBaseURL, async (context) => {
+      this.worker.use(this, tracker.method(), pathWithBaseURL, async (context) => {
         const response = await this.handleInterceptedRequest(
           tracker.method(),
           tracker.path(),
@@ -164,6 +164,7 @@ class InternalHttpInterceptor<Schema extends HttpInterceptorSchema> implements H
       this.bypassMethodTrackers(method);
       this.trackersByMethod[method].clear();
     }
+    this.worker.clearInterceptorHandlers(this);
   }
 
   private bypassMethodTrackers(method: HttpInterceptorMethod) {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -1,23 +1,28 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
-  const baseURL = 'http://localhost:3000';
-  const worker = createHttpInterceptorWorker({ platform });
-
   interface User {
     name: string;
   }
 
   const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
 
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const baseURL = 'http://localhost:3000';
+
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -1,6 +1,7 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
@@ -13,11 +14,15 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
 
-  const worker = createHttpInterceptorWorker({ platform });
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -1,17 +1,22 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareHeadHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
-  const worker = createHttpInterceptorWorker({ platform });
 
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -1,14 +1,15 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
-  const worker = createHttpInterceptorWorker({ platform });
 
   interface Filters {
     name: string;
@@ -16,6 +17,10 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
 
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -1,14 +1,15 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
-  const worker = createHttpInterceptorWorker({ platform });
 
   interface User {
     name: string;
@@ -18,6 +19,10 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -1,14 +1,15 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePostHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
-  const worker = createHttpInterceptorWorker({ platform });
 
   interface User {
     name: string;
@@ -18,6 +19,10 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
 
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -1,14 +1,15 @@
-import { afterAll, beforeAll, expect, expectTypeOf, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
+import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
 import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePutHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
-  const worker = createHttpInterceptorWorker({ platform });
 
   interface User {
     name: string;
@@ -18,6 +19,10 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   beforeAll(async () => {
     await worker.start();
+  });
+
+  afterEach(() => {
+    expect(worker.interceptorsWithHandlers()).toHaveLength(0);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
- feat(#zimic): remove http handlers of cleared interceptors

Closes #57.