### PR TITLE
docs: `README.md` and JSDocs (#19, #22)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,17 @@ concurrency:
 env:
   CI: true
   TURBO_LOG_ORDER: stream
-  TURBO_TOKEN: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && secrets.TURBO_REMOTE_CACHE_TOKEN || '' }}
-  TURBO_TEAM: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && secrets.TURBO_REMOTE_CACHE_TEAM || '' }}
-  INSTALL_OPTIONS: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"...[HEAD^1]"' || '' }}
-  BUILD_OPTIONS: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"{./apps/*}[HEAD^1]^..." "{./packages/*}[HEAD^1]..."' || './packages/*' }}
+  TURBO_TOKEN:
+    ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') &&
+    secrets.TURBO_REMOTE_CACHE_TOKEN || '' }}
+  TURBO_TEAM:
+    ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') &&
+    secrets.TURBO_REMOTE_CACHE_TEAM || '' }}
+  INSTALL_OPTIONS:
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"...[HEAD^1]"' || '' }}
+  BUILD_OPTIONS:
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"{./apps/*}[HEAD^1]^..."
+    "{./packages/*}[HEAD^1]..."' || './packages/*' }}
 
 jobs:
   ci:
@@ -50,7 +57,9 @@ jobs:
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}
           build: ${{ env.BUILD_OPTIONS }}
-          build-node-env: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && 'development' || 'production' }}
+          build-node-env:
+            ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && 'development'
+            || 'production' }}
           install-playwright-browsers: true
 
       - name: Check formatting style

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -9,5 +9,5 @@
   "arrowParens": "always",
   "endOfLine": "lf",
   "proseWrap": "always",
-  "plugins": ["prettier-plugin-sh"]
+  "plugins": ["prettier-plugin-sh", "prettier-plugin-jsdoc"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -8,5 +8,6 @@
   "bracketSpacing": true,
   "arrowParens": "always",
   "endOfLine": "lf",
+  "proseWrap": "always",
   "plugins": ["prettier-plugin-sh"]
 }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,20 +2,15 @@ MIT License
 
 Copyright (c) 2023 Diego Aquino
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,392 @@
-# zimic
+<h1 align="center">
+  Zimic
+</h1>
+
+<p align="center">
+  TypeScript-first HTTP request mocking.
+</p>
+
+> This project is under active development! Check our [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6).
+> Contributors and suggestions are welcome!
+
+Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by [Zod](https://github.com/colinhacks/zod)'s type-inference and using [msw](https://github.com/mswjs/msw) under the hood.
+
+## Features
+
+- **Typed mocks**: declare the HTTP endpoints and get full type-inference and type-validation when applying mocks. Having a single place to declare routes, parameters and responses means an easier time keeping your mocks in sync with the real services!
+- **Network-level intercepts**: internally, Zimic uses [msw](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped and the mocked requests are indistinguishable from the real ones. If you're mocking requests on a browser, you can even inspect the requests and responses on your devtools!
+- **Flexibility**: you can simulate real application workflows by mocking all endpoints used. This is specially useful in testing, making sure the real path your application is covered and allowing checks about how many requests were made and with which parameters.
+- **Simplicity**: no complex configuration files or heavy dependencies. Check our [Getting started](#getting-started) guide and starting mocking!
+- **Compatibility**: browser and Node.js support!
+
+---
+
+## Table of contents
+
+- [Features](#features)
+- [Table of contents](#table-of-contents)
+- [Getting started](#getting-started)
+  - [1. Requirements](#1-requirements)
+  - [2. Install from `npm`](#2-install-from-npm)
+  - [3. Post-install](#3-post-install)
+    - [Node.js post-install](#nodejs-post-install)
+    - [Browser post-install](#browser-post-install)
+- [Usage](#usage)
+  - [Basic usage](#basic-usage)
+  - [Testing](#testing)
+- [Changelog](#changelog)
+- [`zimic/interceptor` API](#zimicinterceptor-api)
+  - [`createNodeHttpInterceptor`](#createnodehttpinterceptor)
+  - [`createBrowserHttpInterceptor`](#createbrowserhttpinterceptor)
+  - [`HttpInterceptor`](#httpinterceptor)
+    - [`interceptor.start()`](#interceptorstart)
+    - [`interceptor.stop()`](#interceptorstop)
+    - [`interceptor.baseURL()`](#interceptorbaseurl)
+    - [`interceptor.isRunning()`](#interceptorisrunning)
+    - [`interceptor.<method>(path)`](#interceptormethodpath)
+    - [`interceptor.clear()`](#interceptorclear)
+  - [`HttpRequestTracker`](#httprequesttracker)
+    - [`tracker.respond(declaration)`](#trackerresponddeclaration)
+    - [`tracker.bypass()`](#trackerbypass)
+    - [`tracker.requests()`](#trackerrequests)
+- [CLI](#cli)
+  - [`zimic --version`](#zimic---version)
+  - [`zimic --help`](#zimic---help)
+  - [`zimic browser init <publicDirectory>`](#zimic-browser-init-publicdirectory)
+- [Development](#development)
+
+## Getting started
+
+### 1. Requirements
+
+- TypeScript >=4.7
+
+- `strict` mode enabled in your `tsconfig.json`:
+  ```json
+  // tsconfig.json
+  {
+    // ...
+    "compilerOptions": {
+      // ...
+      "strict": true
+    }
+  }
+  ```
+
+### 2. Install from `npm`
+
+```bash
+npm install zimic --save-dev # npm
+yarn add zimic --dev         # yarn
+pnpm add zimic --save-dev    # pnpm
+bun add zimic --dev          # bun
+```
+
+Canary versions are released under the `canary` tag:
+
+```bash
+npm install zimic@canary --save-dev # npm
+yarn add zimic@canary --dev         # yarn
+pnpm add zimic@canary --save-dev    # pnpm
+bun add zimic@canary --dev          # bun
+```
+
+### 3. Post-install
+
+#### Node.js post-install
+
+No additional configuration is necessary for Node.js. Check out the [usage](#usage) guide and start mocking!
+
+#### Browser post-install
+
+To use Zimic on a browser, you should first initialize the mock service worker in your public directory:
+
+```bash
+npx zimic browser init <publicDirectory>
+```
+
+This will create a `mockServiceWorker.js` file in the provided public directory, which is necessary to intercept requests and mock responses.
+
+## Usage
+
+### Basic usage
+
+@TODO
+
+Declare the endpoint schema of a service and create an HTTP interceptor:
+
+```ts
+
+```
+
+### Testing
+
+Interceptors must be started to intercept requests. We recommend managing the lifecycle of interceptors with `beforeAll` and `afterAll` hooks in your test setup file, or equivalent depending on your testing framework. An example with Jest/Vitest-like syntax:
+
+```ts
+// tests/setup.ts
+beforeAll(async () => {
+  await interceptor.start(); // starts intercepting requests
+});
+
+beforeEach(async () => {
+  await interceptor.clear(); // clears all applied mocks to make sure no tests affect each other
+});
+
+afterAll(() => {
+  interceptor.stop(); // stops intercepting requests
+});
+```
+
+## Changelog
+
+The changelog is available on our [GitHub Releases](https://github.com/diego-aquino/zimic/releases) page.
+
+---
+
+## `zimic/interceptor` API
+
+This module provides a set of utilities to create HTTP interceptors for both Node.js and browser environments.
+
+All APIs are typed using TypeScript and documented using JSDoc comments, so you can view detailed descriptions directly in your IDE!
+
+### `createNodeHttpInterceptor`
+
+A factory function that creates an `HttpInterceptor` instance for a Node.js environment.
+
+```ts
+import { createNodeHttpInterceptor } from 'zimic/interceptor/node'; // <-- import from `node`
+
+const interceptor = createNodeHttpInterceptor<{
+  '/users': {
+    GET: {
+      response: {
+        200: { body: User };
+        404: { body: NotFoundError };
+      };
+    };
+  };
+}>({
+  baseURL: 'http://localhost:3000',
+});
+```
+
+### `createBrowserHttpInterceptor`
+
+A factory function that creates an `HttpInterceptor` instance for a browser environment.
+
+```ts
+import { createBrowserHttpInterceptor } from 'zimic/interceptor/browser'; // <-- import from `browser`
+
+const interceptor = createBrowserHttpInterceptor<{
+  '/users': {
+    GET: {
+      response: {
+        200: { body: User[] };
+      };
+    };
+  };
+}>({
+  baseURL: 'http://localhost:3000',
+});
+```
+
+### `HttpInterceptor`
+
+HTTP interceptors provide the main API to apply mocks to HTTP requests.
+
+#### `interceptor.start()`
+
+Before using an interceptor, it must be started:
+
+```ts
+await interceptor.start();
+```
+
+#### `interceptor.stop()`
+
+After use, the interceptor must be stopped, after which no more requests will be intercepted:
+
+```ts
+interceptor.stop();
+```
+
+#### `interceptor.baseURL()`
+
+Returns the base URL of the interceptor.
+
+```ts
+const interceptor = createNodeHttpInterceptor<{}>({
+  baseURL: 'http://localhost:3000',
+});
+
+const baseURL = interceptor.baseURL();
+console.log(baseURL); // http://localhost:3000
+```
+
+#### `interceptor.isRunning()`
+
+Returns a boolean indicating whether the interceptor is currently intercepting requests.
+
+```ts
+const interceptor = createNodeHttpInterceptor<{}>({
+  baseURL: 'http://localhost:3000',
+});
+console.log(interceptor.isRunning()); // false
+
+await interceptor.start();
+console.log(interceptor.isRunning()); // true
+
+interceptor.stop();
+console.log(interceptor.isRunning()); // false
+```
+
+#### `interceptor.<method>(path)`
+
+Creates an `HttpRequestTracker` instance for the given method and path. The path must be declared in the interceptor schema (generic passed to `createNodeHttpInterceptor` or `createBrowserHttpInterceptor`).
+
+The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, `options`.
+
+```ts
+const interceptor = createNodeHttpInterceptor<{
+  '/users': {
+    GET: {
+      response: {
+        200: { body: User[] };
+      };
+    };
+  };
+}>({
+  baseURL: 'http://localhost:3000',
+});
+
+const listTracker = interceptor.get('/users')
+
+listTracker.respond({
+  status: 200
+  body: [{ id: 1, name: 'Diego' }],
+});
+```
+
+Paths with dynamic route parameters, such as `/users/:id`, are supported, but it's necessary to explicitly declare the original path to get type-inference and type-validation.
+
+```ts
+const interceptor = createNodeHttpInterceptor<{
+  '/users/:id': {
+    GET: {
+      response: {
+        200: { body: User };
+      };
+    };
+  };
+}>({
+  baseURL: 'http://localhost:3000',
+});
+
+interceptor.get('/users/:id'); // matches any id
+interceptor.get<'/users/:id'>(`/users/${1}`); // only matches id 1 (see the explicit original path as a generic)
+```
+
+#### `interceptor.clear()`
+
+Clears all the applied mocks from the interceptor.
+
+```ts
+interceptor.clear();
+```
+
+After this, all current trackers are marked as unusable. However, if the interceptor is still running, new mocks can be applied creating new trackers with [`interceptor.<method>(path)`](#interceptormethodpath).
+
+Note: clearing an intercetor does not stop it. If you want to stop intercepting requests, use [`interceptor.stop()`](#interceptorstop).
+
+### `HttpRequestTracker`
+
+HTTP request trackers allow specifying specific responses for requests. When multiple trackers match the same method and route, the _last_ created with [`interceptor.<method>(path)`](#interceptormethodpath) will be used.
+
+#### `tracker.respond(declaration)`
+
+Declares a response for a request tracker. When the tracker matches a request, it will respond with the given declaration. The response type is validated against the schema declared in the interceptor.
+
+```ts
+const listTracker = interceptor.get('/users').respond({
+  status: 200,
+  body: [{ id: 1, name: 'Diego' }],
+});
+```
+
+A function is also supported, in case the response is dynamic:
+
+```ts
+const listTracker = interceptor.get('/users').respond((request) => {
+  const { name } = request.body;
+  return {
+    status: 200,
+    body: [{ id: 1, name }],
+  };
+});
+```
+
+#### `tracker.bypass()`
+
+Bypasses the request tracker, meaning that it won't match any more requests. This is useful when you want to skip a tracker in favor of one created before.
+
+```ts
+const listTracker1 = interceptor.get('/users').respond({
+  status: 200,
+  body: [{ id: 1, name: 'Diego' }],
+});
+const listTracker2 = interceptor.get('/users').respond({
+  status: 200,
+  body: [],
+});
+
+listTracker2.bypass();
+
+// GET requests to /users will only match listTracker1
+```
+
+#### `tracker.requests()`
+
+Returns an array of all requests that matched the tracker, were intercepted and responded with the mock declaration.
+
+```ts
+const listTracker = interceptor.get('/users').respond({
+  status: 200,
+  body: [{ id: 1, name: 'Diego' }],
+});
+
+await fetch('http://localhost:3000/users');
+
+const listRequests = listTracker.requests();
+console.log(listRequests.length); // 1
+console.log(listRequests[0].body); // null
+console.log(listRequests[0].response.body); // [{ id: 1, name: 'Diego' }]
+```
+
+The return by `requests` contains simplified objects based on the [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) web APIs, with only the necessary properties for inspection and a body already parsed. If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
+
+```ts
+const listRequests = listTracker.requests();
+console.log(listRequests[0].raw); // Request{}
+console.log(listRequests[0].response.raw); // Response{}
+```
+
+## CLI
+
+### `zimic --version`
+
+Displays the current version of Zimic.
+
+### `zimic --help`
+
+Displays the available commands and options.
+
+### `zimic browser init <publicDirectory>`
+
+Initializes the mock service worker in a public directory. If you are using Zimic mainly in tests, we recommend adding the `mockServiceWorker.js` to your `.gitignore` and adding a `postinstall` scripts to your `package.json`. This ensures that the latest service worker script is being used after upgrading Zimic.
+
+---
+
+## Development
+
+Interested in contributing to Zimic? View our [contributing guide](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -17,20 +17,27 @@
   <br />
 </div>
 
-> 🚧 This project is under active development! Check our [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6).
-> <br />
-> Contributors and ideas are welcome!
+> 🚧 This project is under active development! Check our
+> [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6). <br /> Contributors and ideas are welcome!
 
-Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by [Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
+Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by
+[Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
 
 ## Features
 
 Zimic provides a simple, flexible and type-safe way to mock HTTP requests.
 
-- :zap: **Statically-typed mocks**. Declare your HTTP endpoints and get full type inference and validation when applying mocks.
-- :link: **Network-level intercepts**. Internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a browser, you can even inspect the requests and responses on your devtools!
-- :wrench: **Flexibility**. You can simulate real application workflows by mocking all endpoints used. This is specially useful in testing, making sure the real path your application takes is covered and the requests sent are as expected.
-- :bulb: **Simplicity and opinion**. Having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
+- :zap: **Statically-typed mocks**. Declare your HTTP endpoints and get full type inference and validation when applying
+  mocks.
+- :link: **Network-level intercepts**. Internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP
+  requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you
+  application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a
+  browser, you can even inspect the requests and responses on your devtools!
+- :wrench: **Flexibility**. You can simulate real application workflows by mocking all endpoints used. This is specially
+  useful in testing, making sure the real path your application takes is covered and the requests sent are as expected.
+- :bulb: **Simplicity and opinion**. Having no complex configuration or heavy dependencies, Zimic was designed from
+  scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and
+  starting mocking!
 
 ---
 
@@ -135,7 +142,8 @@ To use Zimic on a browser, you should first initialize the mock service worker i
 npx zimic browser init <publicDirectory>
 ```
 
-This will create a `mockServiceWorker.js` file in the provided public directory, which is necessary to intercept requests and mock responses. We recommend not deploying this file to production.
+This will create a `mockServiceWorker.js` file in the provided public directory, which is necessary to intercept
+requests and mock responses. We recommend not deploying this file to production.
 
 ## Usage
 
@@ -166,7 +174,9 @@ const interceptor = createHttpInterceptor<{
 });
 ```
 
-In this example, we're creating an interceptor for a service with a single path, `/users`, that supports a `GET` method. The response for a successful request is an array of `User` objects. Learn more about how to declare interceptor schemas at [`HttpInterceptor` schema](#httpinterceptor-schema).
+In this example, we're creating an interceptor for a service with a single path, `/users`, that supports a `GET` method.
+The response for a successful request is an array of `User` objects. Learn more about how to declare interceptor schemas
+at [`HttpInterceptor` schema](#httpinterceptor-schema).
 
 Finally, start the worker to intercept requests:
 
@@ -191,7 +201,8 @@ More examples are available at [`zimic/interceptor` API](#zimicinterceptor-api).
 
 ### Testing
 
-We recommend managing the lifecycle of your workers and interceptors using `beforeAll` and `afterAll` hooks in your test setup file. An example using Jest/Vitest structure:
+We recommend managing the lifecycle of your workers and interceptors using `beforeAll` and `afterAll` hooks in your test
+setup file. An example using Jest/Vitest structure:
 
 ```ts
 // tests/setup.ts
@@ -243,11 +254,13 @@ The changelog is available on our [GitHub Releases](https://github.com/diego-aqu
 
 This module provides a set of utilities to create HTTP interceptors for both Node.js and browser environments.
 
-All APIs are documented using [JSDoc](https://jsdoc.ap`) comments, so you can view detailed descriptions directly in your IDE!
+All APIs are documented using [JSDoc](https://jsdoc.ap`) comments, so you can view detailed descriptions directly in
+your IDE!
 
 ### `HttpInterceptorWorker`
 
-Workers are used by [`HttpInterceptor`](#httpinterceptor)'s to intercept HTTP requests and return mock responses. To start intercepting requests, the worker must be started.
+Workers are used by [`HttpInterceptor`](#httpinterceptor)'s to intercept HTTP requests and return mock responses. To
+start intercepting requests, the worker must be started.
 
 In a project, all interceptors can share the same worker.
 
@@ -287,7 +300,9 @@ Starts the worker, allowing it to be used by interceptors.
 await worker.start();
 ```
 
-When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting the worker. This initializes the mock service worker in your public directory. Learn more at [`zimic browser init <publicDirectory`](#zimic-browser-init-publicdirectory).
+When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal
+before starting the worker. This initializes the mock service worker in your public directory. Learn more at
+[`zimic browser init <publicDirectory`](#zimic-browser-init-publicdirectory).
 
 #### `worker.stop()`
 
@@ -307,13 +322,16 @@ const isRunning = worker.isRunning();
 
 ### `HttpInterceptor`
 
-HTTP interceptors provide the main API to handle HTTP requests and return mock responses. The methods, paths, status codes, parameters, and responses are statically-typed based on the service schema. To intercept HTTP requests, an interceptor needs a running [`HttpInterceptorWorker`](#httpinterceptorworker).
+HTTP interceptors provide the main API to handle HTTP requests and return mock responses. The methods, paths, status
+codes, parameters, and responses are statically-typed based on the service schema. To intercept HTTP requests, an
+interceptor needs a running [`HttpInterceptorWorker`](#httpinterceptorworker).
 
 Each interceptor represents a service and can be used to mock its paths and methods.
 
 #### `createHttpInterceptor`
 
-Creates an HTTP interceptor, the main interface to intercept HTTP requests and return responses. Learn more about interceptor schemas at [`HttpInterceptor` schema](#httpinterceptor-schema).
+Creates an HTTP interceptor, the main interface to intercept HTTP requests and return responses. Learn more about
+interceptor schemas at [`HttpInterceptor` schema](#httpinterceptor-schema).
 
 ```ts
 import { createHttpInterceptorWorker, createHttpInterceptor } from 'zimic/interceptor';
@@ -339,7 +357,9 @@ const interceptor = createHttpInterceptor<{
 
 #### `HttpInterceptor` schema
 
-HTTP interceptor schemas define the structure of the real services being mocked. This includes paths, methods, request and response bodies, and status codes. Based on the schema, interceptors will provide type validation when applying mocks.
+HTTP interceptor schemas define the structure of the real services being mocked. This includes paths, methods, request
+and response bodies, and status codes. Based on the schema, interceptors will provide type validation when applying
+mocks.
 
 ##### `HttpInterceptor` schema paths
 
@@ -392,7 +412,8 @@ const interceptor = createHttpInterceptor<UserPaths & PostPaths>({
 
 ##### `HttpInterceptor` schema methods
 
-Each path can have one or more methods, (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`). The method names are case-sensitive.
+Each path can have one or more methods, (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`). The method
+names are case-sensitive.
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -413,7 +434,8 @@ const interceptor = createHttpInterceptor<{
 
 ##### `HttpInterceptor` schema method composition
 
-Similarly to [paths](#httpinterceptor-schema-paths), you can also compose methods using the utility type `HttpInterceptorSchema.Method`:
+Similarly to [paths](#httpinterceptor-schema-paths), you can also compose methods using the utility type
+`HttpInterceptorSchema.Method`:
 
 ```ts
 import { HttpInterceptorSchema } from 'zimic/interceptor';
@@ -437,7 +459,8 @@ const interceptor = createHttpInterceptor<{
 
 ##### `HttpInterceptor` schema requests
 
-Each method can have a `request`, which defines the schema of the accepted requests. Currently, only the `body` property is supported.
+Each method can have a `request`, which defines the schema of the accepted requests. Currently, only the `body` property
+is supported.
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -461,7 +484,8 @@ const interceptor = createHttpInterceptor<{
 
 ##### `HttpInterceptor` schema request composition
 
-You can also compose requests using the utility type `HttpInterceptorSchema.Request`, similarly to [methods](#httpinterceptor-schema-methods):
+You can also compose requests using the utility type `HttpInterceptorSchema.Request`, similarly to
+[methods](#httpinterceptor-schema-methods):
 
 ```ts
 import { HttpInterceptorSchema } from 'zimic/interceptor';
@@ -486,7 +510,8 @@ const interceptor = createHttpInterceptor<{
 
 ##### `HttpInterceptor` schema responses
 
-Each method can also have a `response`, which defines the schema of the returned responses. The status codes are used as keys. Currently, only the `body` property is supported.
+Each method can also have a `response`, which defines the schema of the returned responses. The status codes are used as
+keys. Currently, only the `body` property is supported.
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -509,7 +534,8 @@ const interceptor = createHttpInterceptor<{
 
 ##### `HttpInterceptor` schema response composition
 
-You can also compose responses using the utility types `HttpInterceptorSchema.ResponseByStatusCode` and `HttpInterceptorSchema.Response`, similarly to [requests](#httpinterceptor-schema-requests):
+You can also compose responses using the utility types `HttpInterceptorSchema.ResponseByStatusCode` and
+`HttpInterceptorSchema.Response`, similarly to [requests](#httpinterceptor-schema-requests):
 
 ```ts
 import { HttpInterceptorSchema } from 'zimic/interceptor';
@@ -657,7 +683,8 @@ const baseURL = interceptor.baseURL();
 
 #### `interceptor.<method>(path)`
 
-Creates an [`HttpRequestTracker`](#httprequesttracker) for the given method and path. The path and method must be declared in the interceptor schema.
+Creates an [`HttpRequestTracker`](#httprequesttracker) for the given method and path. The path and method must be
+declared in the interceptor schema.
 
 The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and `options`.
 
@@ -684,7 +711,8 @@ const listTracker = interceptor.get('/users').respond({
 
 ##### Dynamic path parameters
 
-Paths with dynamic path parameters, such as `/users/:id`, are supported, but you need to specify the original path as a type parameter to get type validation.
+Paths with dynamic path parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+type parameter to get type validation.
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -711,7 +739,9 @@ interceptor.get<'/users/:id'>(`/users/${1}`); // only matches id 1 (notice the o
 
 #### `interceptor.clear()`
 
-Clears all of the [`HttpRequestTracker`](#httprequesttracker) instances created by this interceptor, including their registered responses and intercepted requests. After calling this method, the interceptor will no longer intercept any requests until new mock responses are registered.
+Clears all of the [`HttpRequestTracker`](#httprequesttracker) instances created by this interceptor, including their
+registered responses and intercepted requests. After calling this method, the interceptor will no longer intercept any
+requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
@@ -721,9 +751,12 @@ interceptor.clear();
 
 ### `HttpRequestTracker`
 
-HTTP request trackers allow declaring responses to return for matched intercepted requests. They also keep track of the intercepted requests and their responses, allowing checks about how many requests your application made and with which parameters.
+HTTP request trackers allow declaring responses to return for matched intercepted requests. They also keep track of the
+intercepted requests and their responses, allowing checks about how many requests your application made and with which
+parameters.
 
-When multiple trackers match the same method and path, the _last_ created with [`interceptor.<method>(path)`](#interceptormethodpath) will be used.
+When multiple trackers match the same method and path, the _last_ created with
+[`interceptor.<method>(path)`](#interceptormethodpath) will be used.
 
 #### `tracker.method()`
 
@@ -737,7 +770,8 @@ console.log(method); // 'POST'
 
 #### `tracker.path()`
 
-Returns the path that matches this tracker. The base URL of the interceptor is not included, but it is used when matching requests.
+Returns the path that matches this tracker. The base URL of the interceptor is not included, but it is used when
+matching requests.
 
 ```ts
 const tracker = interceptor.get('/users');
@@ -749,7 +783,8 @@ console.log(path); // '/users'
 
 Declares a response to return for matched intercepted requests.
 
-When the tracker matches a request, it will respond with the given declaration. The response type is statically validated against the schema of the interceptor.
+When the tracker matches a request, it will respond with the given declaration. The response type is statically
+validated against the schema of the interceptor.
 
 ##### Static responses
 
@@ -777,7 +812,9 @@ const listTracker = interceptor.get('/users').respond((request) => {
 
 #### `tracker.bypass()`
 
-Clears any declared response and intercepted requests, and makes the tracker stop matching intercepted requests. The next tracker, created before this one, that matches the same method and path will be used if present. If not, the requests to the method and path will not be intercepted.
+Clears any declared response and intercepted requests, and makes the tracker stop matching intercepted requests. The
+next tracker, created before this one, that matches the same method and path will be used if present. If not, the
+requests to the method and path will not be intercepted.
 
 ```ts
 const listTracker1 = interceptor.get('/users').respond({
@@ -797,7 +834,8 @@ listTracker2.bypass();
 
 #### `tracker.requests()`
 
-Returns the intercepted requests that matched this tracker, along with the responses returned to each of them. This is useful for testing that the correct requests were made by your application.
+Returns the intercepted requests that matched this tracker, along with the responses returned to each of them. This is
+useful for testing that the correct requests were made by your application.
 
 ```ts
 const updateTracker = interceptor.put('/users/:id').respond((request) => {
@@ -819,7 +857,10 @@ expect(updateRequests[0].url).toEqual('http://localhost:3000/users/1');
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-The return by `requests` contains simplified objects based on the [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) web APIs, containing an already parsed body in `.body`. If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
+The return by `requests` contains simplified objects based on the
+[`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
+[`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) web APIs, containing an already parsed body in
+`.body`. If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
 
 ```ts
 const listRequests = listTracker.requests();
@@ -841,9 +882,12 @@ Displays the available commands and options.
 
 Initializes the mock service worker in a public directory.
 
-This command is necessary when using Zimic in a browser environment. It creates a `mockServiceWorker.js` file in the provided public directory, which is used to intercept requests and mock responses.
+This command is necessary when using Zimic in a browser environment. It creates a `mockServiceWorker.js` file in the
+provided public directory, which is used to intercept requests and mock responses.
 
-If you are using Zimic mainly in tests, we recommend adding the `mockServiceWorker.js` to your `.gitignore` and adding this command to a `postinstall` scripts in your `package.json`. This ensures that the latest service worker script is being used after upgrading Zimic.
+If you are using Zimic mainly in tests, we recommend adding the `mockServiceWorker.js` to your `.gitignore` and adding
+this command to a `postinstall` scripts in your `package.json`. This ensures that the latest service worker script is
+being used after upgrading Zimic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired 
 
 ## Features
 
-- **Typed mocks**: declare the HTTP endpoints and get full type-inference and type-validation when applying mocks. Having a single place to declare routes, parameters and responses means an easier time keeping your mocks in sync with the real services!
-- **Network-level intercepts**: internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped and the mocked requests are indistinguishable from the real ones. If you're mocking requests on a browser, you can even inspect the requests and responses on your devtools!
-- **Flexibility**: you can simulate real application workflows by mocking all endpoints used. This is specially useful in testing, making sure the real path your application is covered and allowing checks about how many requests were made and with which parameters.
-- **Simplicity**: no complex configuration files or heavy dependencies. Check our [Getting started](#getting-started) guide and starting mocking!
-- **Compatibility**: browser and Node.js support!
+- **Typed mocks**: declare your HTTP endpoints and get full type-inference and type validation when applying mocks.
+- **Network-level intercepts**: internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a browser, you can even inspect the requests and responses on your devtools!
+- **Flexibility**: you can simulate real application workflows by mocking each endpoints used. This is specially useful in testing, making sure the real path your application is covered and allowing checks about how many requests were made and with which parameters.
+- **Simplicity**: having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
 
 ---
 
@@ -67,7 +66,6 @@ Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired 
 
 - `strict` mode enabled in your `tsconfig.json`:
   ```jsonc
-  // tsconfig.json
   {
     // ...
     "compilerOptions": {
@@ -117,7 +115,7 @@ This will create a `mockServiceWorker.js` file in the provided public directory,
 
 ### Testing
 
-Interceptor workers must be started so that their interceptors handle requests. We recommend managing the lifecycle of interceptors with `beforeAll` and `afterAll` hooks in your test setup file, or equivalent depending on your testing framework. An example with Jest/Vitest-like syntax:
+We recommend managing the lifecycle of your workers and interceptors using `beforeAll` and `afterAll` hooks in your test setup file. An example with Jest/Vitest-like syntax:
 
 ```ts
 // tests/setup.ts
@@ -128,16 +126,15 @@ const worker = createHttpInterceptorWorker({
   platform: 'node',
 });
 
-// declare your interceptors
 const userInterceptor = createHttpInterceptor<{
-  // ...
+  // declare your schema
 }>({
   worker,
   baseURL: 'http://localhost:3000',
 });
 
 const logInterceptor = createHttpInterceptor<{
-  // ...
+  // declare your schema
 }>({
   worker,
   baseURL: 'http://localhost:3001',
@@ -174,11 +171,13 @@ All APIs are typed using TypeScript and documented using JSDoc comments, so you 
 
 ### `HttpInterceptorWorker`
 
-Worker responsible for intercepting HTTP requests and returning mock responses, compatible with browser and Node.js. All interceptors in a project can share the same worker. To start intercepting requests, the worker must be started.
+Workers are used by [HttpInterceptor](#httpinterceptor)'s to intercept HTTP requests and return mock responses. To start intercepting requests, the worker must be started.
+
+In a project, all interceptors can share the same worker.
 
 #### `createHttpInterceptorWorker`
 
-Creates a new HTTP interceptor worker instance. A platform is required to specify the environment where the worker will be running.
+Creates an HTTP interceptor worker. A platform is required to specify the environment where the worker will be running:
 
 - Node.js:
 
@@ -206,17 +205,17 @@ const platform = worker.platform();
 
 #### `worker.start()`
 
-Starts the worker, allowing it to intercept HTTP requests.
+Starts the worker, allowing it to be used by interceptors.
 
 ```ts
 await worker.start();
 ```
 
-When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting a worker. This initializes the mock service worker in your public directory. Learn more at [`zimic browser init <publicDirectory`](#workerstart).
+When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting the worker. This initializes the mock service worker in your public directory. Learn more at [`zimic browser init <publicDirectory`](#workerstart).
 
 #### `worker.stop()`
 
-Stops the worker, preventing it from intercepting HTTP requests.
+Stops the worker, preventing it from being used by interceptors.
 
 ```ts
 await worker.stop();
@@ -224,7 +223,7 @@ await worker.stop();
 
 #### `worker.isRunning()`
 
-Returns whether the worker is currently running and able to intercept HTTP requests.
+Returns whether the worker is currently running and ready to use.
 
 ```ts
 const isRunning = worker.isRunning();
@@ -232,16 +231,16 @@ const isRunning = worker.isRunning();
 
 ### `HttpInterceptor`
 
-HTTP interceptors provide the main API to apply mocks to HTTP requests.
+HTTP interceptors provide the main API to handle matched HTTP requests and return mock responses. The methods, paths, status codes, parameters, and responses are statically-typed based on the provided service schema. To intercept HTTP requests, an interceptor needs a running [HttpInterceptorWorker](#httpinterceptorworker).
 
 #### `createHttpInterceptor`
 
-Creates a new HTTP interceptor instance.
+Creates an HTTP interceptor.
 
-The interceptor schema is used to declare the structure of the real service being mocked. This includes routes, methods, request and response bodies, and status codes. Based on the schema, the interceptor will provide type-inference and type-validation when applying mocks.
+The interceptor schema defines the structure of the real service being mocked. This includes routes, methods, request and response bodies, and status codes. Based on the schema, the interceptor will provide type validation when applying mocks.
 
 ```ts
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { createHttpInterceptorWorker, createHttpInterceptor } from 'zimic/interceptor';
 
 const worker = createHttpInterceptorWorker({
   platform: 'node',
@@ -276,7 +275,7 @@ const baseURL = interceptor.baseURL();
 
 #### `interceptor.<method>(path)`
 
-Creates an [`HttpRequestTracker`](#httprequesttracker) instance for the given method and path. The path and method must be declared in the interceptor schema.
+Creates an [`HttpRequestTracker`](#httprequesttracker) for the given method and path. The path and method must be declared in the interceptor schema.
 
 The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, `options`.
 
@@ -294,14 +293,14 @@ const interceptor = createHttpInterceptor<{
   baseURL: 'http://localhost:3000',
 });
 
-// any GET requests to http://localhost:3000/users will be intercepted and returned with the given response
+// intercept any GET requests to http://localhost:3000/users and return this response
 const listTracker = interceptor.get('/users').respond({
   status: 200
   body: [{ username: 'diego-aquino' }],
 });
 ```
 
-Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path as a type parameter to get type-inference and type-validation.
+Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path as a type parameter to get type validation.
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -318,12 +317,12 @@ const interceptor = createHttpInterceptor<{
 });
 
 interceptor.get('/users/:id'); // matches any id
-interceptor.get<'/users/:id'>(`/users/${1}`); // only matches id 1 (see the original path as a type parameter)
+interceptor.get<'/users/:id'>(`/users/${1}`); // only matches id 1 (notice the original path as a type parameter)
 ```
 
 #### `interceptor.clear()`
 
-Clears all of the [HttpRequestTracker](#httprequesttracker) instances created by this interceptor. After calling this method, the interceptor will no longer intercept any requests until new mock responses are registered.
+Clears all of the [HttpRequestTracker](#httprequesttracker) instances created by this interceptor, including their registered responses and saved intercepted requests. After calling this method, the interceptor will no longer intercept any requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
@@ -333,7 +332,7 @@ interceptor.clear();
 
 ### `HttpRequestTracker`
 
-Tracker for intercepted HTTP requests, supporting response declarations to return for matched intercepted requests.
+HTTP request trackers allow declaring responses to return for matched intercepted requests. They also keep track of the intercepted requests and their responses, allowing checks about how many requests your application made and with which parameters.
 
 When multiple trackers match the same method and route, the _last_ created with [`interceptor.<method>(path)`](#interceptormethodpath) will be used.
 
@@ -342,15 +341,19 @@ When multiple trackers match the same method and route, the _last_ created with 
 Returns the method that matches this tracker.
 
 ```ts
+const tracker = interceptor.post('/users');
 const method = tracker.method();
+console.log(method); // 'POST'
 ```
 
 #### `tracker.path()`
 
-Returns the path that matches this tracker. The base URL of the interceptor is not included, but it is used when checking for intercepted request matches.
+Returns the path that matches this tracker. The base URL of the interceptor is not included, but it is used when matching requests.
 
 ```ts
+const tracker = interceptor.get('/users');
 const path = tracker.path();
+console.log(path); // '/users'
 ```
 
 #### `tracker.respond(declaration)`
@@ -381,7 +384,7 @@ const listTracker = interceptor.get('/users').respond((request) => {
 
 #### `tracker.bypass()`
 
-Clears any declared response and makes the tracker stop matching intercepted requests. The next tracker, created before this one, that matches the same method and path will be used if present. If not, the requests of the method and path will not be intercepted.
+Clears any declared response and saved intercepted requests, and makes the tracker stop matching intercepted requests. The next tracker, created before this one, that matches the same method and path will be used if present. If not, the requests to the method and path will not be intercepted.
 
 ```ts
 const listTracker1 = interceptor.get('/users').respond({
@@ -404,20 +407,26 @@ listTracker2.bypass();
 Returns the intercepted requests that matched this tracker, along with the responses returned to each of them. This is useful for testing that the correct requests were made by your application.
 
 ```ts
-const listTracker = interceptor.get('/users').respond({
-  status: 200,
-  body: [{ username: 'diego-aquino' }],
+const updateTracker = interceptor.put('/users/:id').respond((request) => {
+  const newUsername = request.body.username;
+  return {
+    status: 200,
+    body: [{ username: newUsername }],
+  };
 });
 
-await fetch('http://localhost:3000/users');
+await fetch(`http://localhost:3000/users/${1}`, {
+  method: 'PUT',
+  body: JSON.stringify({ username: 'new' }),
+});
 
-const listRequests = listTracker.requests();
-console.log(listRequests.length); // 1
-console.log(listRequests[0].body); // null
-console.log(listRequests[0].response.body); // [{ username: 'diego-aquino' }]
+const updateRequests = updateTracker.requests();
+expect(updateRequests).toHaveLength(1);
+expect(updateRequests[0].url).toEqual('http://localhost:3000/users/1');
+expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-The return by `requests` contains simplified objects based on the [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) web APIs, with only the necessary properties for inspection and a body already parsed. If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
+The return by `requests` contains simplified objects based on the [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) web APIs, containing an already parsed body in `.body`. If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
 
 ```ts
 const listRequests = listTracker.requests();

--- a/README.md
+++ b/README.md
@@ -6,8 +6,20 @@
   TypeScript-first HTTP request mocking.
 </p>
 
-> This project is under active development! Check our [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6).
-> Contributors and suggestions are welcome!
+<div align="center">
+  <a href="https://www.npmjs.com/package/zimic">npm</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="#table-of-contents">Documentation</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://github.com/diego-aquino/zimic/issues/new">Issues</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://github.com/users/diego-aquino/projects/5">Roadmap</a>
+  <br />
+</div>
+
+> 🚧 This project is under active development! Check our [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6).
+> <br />
+> Contributors and ideas are welcome!
 
 Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by [Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
 
@@ -15,10 +27,10 @@ Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired 
 
 Zimic provides a simple, flexible and type-safe way to mock HTTP requests.
 
-- **Statically-typed mocks**: declare your HTTP endpoints and get full type inference and validation when applying mocks.
-- **Network-level intercepts**: internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a browser, you can even inspect the requests and responses on your devtools!
-- **Flexibility**: you can simulate real application workflows by mocking each endpoints used. This is specially useful in testing, making sure the real path your application is covered and allowing checks about how many requests were made and with which parameters.
-- **Simplicity and opinion**: having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
+- :zap: **Statically-typed mocks**. Declare your HTTP endpoints and get full type inference and validation when applying mocks.
+- :link: **Network-level intercepts**. Internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a browser, you can even inspect the requests and responses on your devtools!
+- :wrench: **Flexibility**. You can simulate real application workflows by mocking all endpoints used. This is specially useful in testing, making sure the real path your application takes is covered and the requests sent are as expected.
+- :bulb: **Simplicity and opinion**. Having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
 
 ---
 
@@ -96,7 +108,7 @@ Zimic provides a simple, flexible and type-safe way to mock HTTP requests.
 ```bash
 npm install zimic --save-dev # npm
 yarn add zimic --dev         # yarn
-pnpm add zimic --save-dev    # pnpm
+pnpm add zimic --dev         # pnpm
 bun add zimic --dev          # bun
 ```
 
@@ -105,7 +117,7 @@ Canary versions are released under the `canary` tag:
 ```bash
 npm install zimic@canary --save-dev # npm
 yarn add zimic@canary --dev         # yarn
-pnpm add zimic@canary --save-dev    # pnpm
+pnpm add zimic@canary --dev         # pnpm
 bun add zimic@canary --dev          # bun
 ```
 
@@ -123,7 +135,7 @@ To use Zimic on a browser, you should first initialize the mock service worker i
 npx zimic browser init <publicDirectory>
 ```
 
-This will create a `mockServiceWorker.js` file in the provided public directory, which is necessary to intercept requests and mock responses.
+This will create a `mockServiceWorker.js` file in the provided public directory, which is necessary to intercept requests and mock responses. We recommend not deploying this file to production.
 
 ## Usage
 
@@ -179,7 +191,7 @@ More examples are available at [`zimic/interceptor` API](#zimicinterceptor-api).
 
 ### Testing
 
-We recommend managing the lifecycle of your workers and interceptors using `beforeAll` and `afterAll` hooks in your test setup file. An example with Jest/Vitest-like syntax:
+We recommend managing the lifecycle of your workers and interceptors using `beforeAll` and `afterAll` hooks in your test setup file. An example using Jest/Vitest structure:
 
 ```ts
 // tests/setup.ts
@@ -231,11 +243,11 @@ The changelog is available on our [GitHub Releases](https://github.com/diego-aqu
 
 This module provides a set of utilities to create HTTP interceptors for both Node.js and browser environments.
 
-All APIs are typed using TypeScript and documented using JSDoc comments, so you can view detailed descriptions directly in your IDE!
+All APIs are documented using [JSDoc](https://jsdoc.ap`) comments, so you can view detailed descriptions directly in your IDE!
 
 ### `HttpInterceptorWorker`
 
-Workers are used by [HttpInterceptor](#httpinterceptor)'s to intercept HTTP requests and return mock responses. To start intercepting requests, the worker must be started.
+Workers are used by [`HttpInterceptor`](#httpinterceptor)'s to intercept HTTP requests and return mock responses. To start intercepting requests, the worker must be started.
 
 In a project, all interceptors can share the same worker.
 
@@ -275,7 +287,7 @@ Starts the worker, allowing it to be used by interceptors.
 await worker.start();
 ```
 
-When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting the worker. This initializes the mock service worker in your public directory. Learn more at [`zimic browser init <publicDirectory`](#workerstart).
+When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting the worker. This initializes the mock service worker in your public directory. Learn more at [`zimic browser init <publicDirectory`](#zimic-browser-init-publicdirectory).
 
 #### `worker.stop()`
 
@@ -295,15 +307,13 @@ const isRunning = worker.isRunning();
 
 ### `HttpInterceptor`
 
-HTTP interceptors provide the main API to handle matched HTTP requests and return mock responses. The methods, paths, status codes, parameters, and responses are statically-typed based on the provided service schema. To intercept HTTP requests, an interceptor needs a running [HttpInterceptorWorker](#httpinterceptorworker).
+HTTP interceptors provide the main API to handle HTTP requests and return mock responses. The methods, paths, status codes, parameters, and responses are statically-typed based on the service schema. To intercept HTTP requests, an interceptor needs a running [`HttpInterceptorWorker`](#httpinterceptorworker).
 
 Each interceptor represents a service and can be used to mock its paths and methods.
 
 #### `createHttpInterceptor`
 
-Creates an HTTP interceptor.
-
-The interceptor schema defines the structure of the real service being mocked. This includes paths, methods, request and response bodies, and status codes. Based on the schema, the interceptor will provide type validation when applying mocks.
+Creates an HTTP interceptor, the main interface to intercept HTTP requests and return responses. Learn more about interceptor schemas at [`HttpInterceptor` schema](#httpinterceptor-schema).
 
 ```ts
 import { createHttpInterceptorWorker, createHttpInterceptor } from 'zimic/interceptor';
@@ -329,11 +339,11 @@ const interceptor = createHttpInterceptor<{
 
 #### `HttpInterceptor` schema
 
-HTTP interceptor schemas are defined using types or interfaces.
+HTTP interceptor schemas define the structure of the real services being mocked. This includes paths, methods, request and response bodies, and status codes. Based on the schema, interceptors will provide type validation when applying mocks.
 
 ##### `HttpInterceptor` schema paths
 
-At the root level, each key represents a path or path:
+At the root level, each key represents a path or route:
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -357,6 +367,8 @@ const interceptor = createHttpInterceptor<{
 As an alternative, you can also compose root level paths using the utility type `HttpInterceptorSchema.Root`:
 
 ```ts
+import { HttpInterceptorSchema } from 'zimic/interceptor';
+
 type UserPaths = HttpInterceptorSchema.Root<{
   '/users': {
     // path schema
@@ -404,6 +416,8 @@ const interceptor = createHttpInterceptor<{
 Similarly to [paths](#httpinterceptor-schema-paths), you can also compose methods using the utility type `HttpInterceptorSchema.Method`:
 
 ```ts
+import { HttpInterceptorSchema } from 'zimic/interceptor';
+
 type UserMethods = HttpInterceptorSchema.Method<{
   GET: {
     // method schema
@@ -450,6 +464,8 @@ const interceptor = createHttpInterceptor<{
 You can also compose requests using the utility type `HttpInterceptorSchema.Request`, similarly to [methods](#httpinterceptor-schema-methods):
 
 ```ts
+import { HttpInterceptorSchema } from 'zimic/interceptor';
+
 type UserCreationRequest = HttpInterceptorSchema.Request<{
   body: {
     username: string;
@@ -496,6 +512,8 @@ const interceptor = createHttpInterceptor<{
 You can also compose responses using the utility types `HttpInterceptorSchema.ResponseByStatusCode` and `HttpInterceptorSchema.Response`, similarly to [requests](#httpinterceptor-schema-requests):
 
 ```ts
+import { HttpInterceptorSchema } from 'zimic/interceptor';
+
 type SuccessUserGetResponse = HttpInterceptorSchema.Response<{
   body: User;
 }>;
@@ -526,7 +544,7 @@ const interceptor = createHttpInterceptor<{
 
 ##### `HttpInterceptor` schema (example)
 
-Combining all of these, you can define a complete schema for your services:
+Combining all of the above, here's an example of a complete interceptor schema:
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -576,6 +594,8 @@ const interceptor = createHttpInterceptor<{
 Alternatively, you can compose the schema using utility types:
 
 ```ts
+import { HttpInterceptorSchema } from 'zimic/interceptor';
+
 type UserPaths = HttpInterceptorSchema.Root<{
   '/users': {
     POST: {
@@ -619,7 +639,9 @@ type PostPaths = HttpInterceptorSchema.Root<{
   };
 }>;
 
-const interceptor = createHttpInterceptor<UserPaths & UserByIdPaths & PostPaths>({
+type InterceptorSchema = HttpInterceptorSchema.Root<UserPaths & UserByIdPaths & PostPaths>;
+
+const interceptor = createHttpInterceptor<InterceptorSchema>({
   worker,
   baseURL: 'http://localhost:3000',
 });
@@ -637,7 +659,7 @@ const baseURL = interceptor.baseURL();
 
 Creates an [`HttpRequestTracker`](#httprequesttracker) for the given method and path. The path and method must be declared in the interceptor schema.
 
-The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, `options`.
+The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and `options`.
 
 ```ts
 const interceptor = createHttpInterceptor<{
@@ -667,9 +689,14 @@ Paths with dynamic path parameters, such as `/users/:id`, are supported, but you
 ```ts
 const interceptor = createHttpInterceptor<{
   '/users/:id': {
-    GET: {
+    PUT: {
+      request: {
+        body: {
+          username: string;
+        };
+      };
       response: {
-        200: { body: User };
+        204: {};
       };
     };
   };
@@ -684,7 +711,7 @@ interceptor.get<'/users/:id'>(`/users/${1}`); // only matches id 1 (notice the o
 
 #### `interceptor.clear()`
 
-Clears all of the [HttpRequestTracker](#httprequesttracker) instances created by this interceptor, including their registered responses and saved intercepted requests. After calling this method, the interceptor will no longer intercept any requests until new mock responses are registered.
+Clears all of the [`HttpRequestTracker`](#httprequesttracker) instances created by this interceptor, including their registered responses and intercepted requests. After calling this method, the interceptor will no longer intercept any requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
@@ -750,7 +777,7 @@ const listTracker = interceptor.get('/users').respond((request) => {
 
 #### `tracker.bypass()`
 
-Clears any declared response and saved intercepted requests, and makes the tracker stop matching intercepted requests. The next tracker, created before this one, that matches the same method and path will be used if present. If not, the requests to the method and path will not be intercepted.
+Clears any declared response and intercepted requests, and makes the tracker stop matching intercepted requests. The next tracker, created before this one, that matches the same method and path will be used if present. If not, the requests to the method and path will not be intercepted.
 
 ```ts
 const listTracker1 = interceptor.get('/users').respond({

--- a/README.md
+++ b/README.md
@@ -11,25 +11,11 @@
 
 Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by [Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
 
-## Why
-
-Mocking is hard. It's a trade-off between simulating real application workflows and keeping tests simple and maintainable. However, many things can go wrong:
-
-- If mocking application code:
-  - Mocking parts of your codebase could lead to false positives, since not all components are really being executed.
-- If mocking at the network-level (intercepting requests):
-  - There's no guarantee that the mocks match the real service's interfaces and behavior. The service being mocked might change and client tests still pass even though the application won't work on production.
-  - TypeScript's type inference and validation are not always available when applying mocks, leading to possibly outdated or faulty mocks.
-  - Verifying that the application made the correct requests might not be straightforward.
-  - Each project might have its own abstractions for mocking requests, which makes it hard to understand and maintain the mocks across the codebase.
-
-So, what do we do about it? Thats where Zimic comes in.
-
 ## Features
 
-Zimic was designed to provide a simple, flexible and type-safe way to mock HTTP requests.
+Zimic provides a simple, flexible and type-safe way to mock HTTP requests.
 
-- **Typed mocks**: declare your HTTP endpoints and get full type inference and validation when applying mocks.
+- **Statically-typed mocks**: declare your HTTP endpoints and get full type inference and validation when applying mocks.
 - **Network-level intercepts**: internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a browser, you can even inspect the requests and responses on your devtools!
 - **Flexibility**: you can simulate real application workflows by mocking each endpoints used. This is specially useful in testing, making sure the real path your application is covered and allowing checks about how many requests were made and with which parameters.
 - **Simplicity and opinion**: having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
@@ -38,7 +24,6 @@ Zimic was designed to provide a simple, flexible and type-safe way to mock HTTP 
 
 ## Table of contents
 
-- [Why](#why)
 - [Features](#features)
 - [Table of contents](#table-of-contents)
 - [Getting started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -9,19 +9,36 @@
 > This project is under active development! Check our [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6).
 > Contributors and suggestions are welcome!
 
-Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by [Zod](https://github.com/colinhacks/zod)'s type-inference and using [MSW](https://github.com/mswjs/msw) under the hood.
+Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by [Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
+
+## Why
+
+Mocking is hard. It's a trade-off between simulating real application workflows and keeping tests simple and maintainable. However, many things can go wrong:
+
+- If mocking application code:
+  - Mocking parts of your codebase could lead to false positives, since not all components are really being executed.
+- If mocking at the network-level (intercepting requests):
+  - There's no guarantee that the mocks match the real service's interfaces and behavior. The service being mocked might change and client tests still pass even though the application won't work on production.
+  - TypeScript's type inference and validation are not always available when applying mocks, leading to possibly outdated or faulty mocks.
+  - Verifying that the application made the correct requests might not be straightforward.
+  - Each project might have its own abstractions for mocking requests, which makes it hard to understand and maintain the mocks across the codebase.
+
+So, what do we do about it? Thats where Zimic comes in.
 
 ## Features
 
-- **Typed mocks**: declare your HTTP endpoints and get full type-inference and type validation when applying mocks.
+Zimic was designed to provide a simple, flexible and type-safe way to mock HTTP requests.
+
+- **Typed mocks**: declare your HTTP endpoints and get full type inference and validation when applying mocks.
 - **Network-level intercepts**: internally, Zimic uses [MSW](https://github.com/mswjs/msw), which intercepts HTTP requests right _before_ they leave your app. This means that no parts of your code are stubbed or skipped. From you application's point of view, the mocked requests are indistinguishable from the real ones. If you're mocking on a browser, you can even inspect the requests and responses on your devtools!
 - **Flexibility**: you can simulate real application workflows by mocking each endpoints used. This is specially useful in testing, making sure the real path your application is covered and allowing checks about how many requests were made and with which parameters.
-- **Simplicity**: having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
+- **Simplicity and opinion**: having no complex configuration or heavy dependencies, Zimic was designed from scratch to encourage clarity, simplicity and standardization. Check our [Getting started](#getting-started) guide and starting mocking!
 
 ---
 
 ## Table of contents
 
+- [Why](#why)
 - [Features](#features)
 - [Table of contents](#table-of-contents)
 - [Getting started](#getting-started)

--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -7,7 +7,6 @@ import {
   type DefaultBody,
   type HttpInterceptor,
   type HttpInterceptorMethod,
-  type HttpInterceptorMethodHandler,
   type HttpInterceptorMethodSchema,
   type HttpInterceptorOptions,
   type HttpInterceptorPathSchema,
@@ -57,7 +56,6 @@ describe('Exports', () => {
     expectTypeOf<TrackedHttpInterceptorRequest<never>>().not.toBeAny();
     expectTypeOf<HttpRequestTracker<never, never, never>>().not.toBeAny();
 
-    expectTypeOf<HttpInterceptorMethodHandler<never, never>>().not.toBeAny();
     expectTypeOf<HttpInterceptorOptions>().not.toBeAny();
     expectTypeOf<HttpInterceptorMethod>().not.toBeAny();
     expectTypeOf<HttpInterceptorRequestSchema>().not.toBeAny();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "pre:push": "pnpm style:check && turbo types:check lint:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 75% && turbo test:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 1",
     "prepare": "husky install || echo 'Could not install git hooks with husky.'"
   },
-  "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "^18.4.4",
     "@commitlint/config-conventional": "^18.4.4",
@@ -34,6 +33,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^15.2.0",
     "prettier": "^3.2.0",
+    "prettier-plugin-jsdoc": "^1.3.0",
     "prettier-plugin-sh": "^0.13.1",
     "turbo": "^1.11.3"
   }

--- a/packages/zimic/LICENSE.md
+++ b/packages/zimic/LICENSE.md
@@ -2,20 +2,15 @@ MIT License
 
 Copyright (c) 2023 Diego Aquino
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "files": [
     "package.json",
-    "README.md",
+    "../../README.md",
     "LICENSE.md",
     "dist",
     "index.d.ts",

--- a/packages/zimic/src/interceptor/http/interceptor/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/factory.ts
@@ -7,9 +7,7 @@ import { HttpInterceptorSchema } from './types/schema';
  * Creates an HTTP interceptor.
  *
  * @param {HttpInterceptorOptions} options The options for the interceptor.
- *
  * @returns {HttpInterceptor} The created HTTP interceptor.
- *
  * @see {@link https://github.com/diego-aquino/zimic#createhttpinterceptor}
  */
 export function createHttpInterceptor<Schema extends HttpInterceptorSchema>(

--- a/packages/zimic/src/interceptor/http/interceptor/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/factory.ts
@@ -3,6 +3,15 @@ import { HttpInterceptorOptions } from './types/options';
 import { HttpInterceptor } from './types/public';
 import { HttpInterceptorSchema } from './types/schema';
 
+/**
+ * Creates an HTTP interceptor.
+ *
+ * @param {HttpInterceptorOptions} options The options for the interceptor.
+ *
+ * @returns {HttpInterceptor} The created HTTP interceptor.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#createhttpinterceptor}
+ */
 export function createHttpInterceptor<Schema extends HttpInterceptorSchema>(
   options: HttpInterceptorOptions,
 ): HttpInterceptor<Schema> {

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -7,8 +7,6 @@ export interface HttpInterceptorOptions {
    */
   worker: HttpInterceptorWorker;
 
-  /**
-   * The base URL used by the interceptor. This URL will be prepended to any routes used by the interceptor.
-   */
+  /** The base URL used by the interceptor. This URL will be prepended to any routes used by the interceptor. */
   baseURL: string;
 }

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -1,6 +1,14 @@
 import { HttpInterceptorWorker } from '../../interceptorWorker/types/public';
 
 export interface HttpInterceptorOptions {
+  /**
+   * The {@link https://github.com/diego-aquino/zimic#httpinterceptorworker HttpInterceptorWorker} instance for the
+   * interceptor. The worker must be running for this interceptor to intercept requests.
+   */
   worker: HttpInterceptorWorker;
+
+  /**
+   * The base URL used by the interceptor. This URL will be prepended to any routes used by the interceptor.
+   */
   baseURL: string;
 }

--- a/packages/zimic/src/interceptor/http/interceptor/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/public.ts
@@ -1,16 +1,108 @@
 import { HttpInterceptorMethodHandler } from './handlers';
 import { HttpInterceptorSchema } from './schema';
 
+/**
+ * Interceptor to handle matched HTTP requests and return mock responses. The methods, paths, status codes, parameters
+ * and responses are statically-typed based on the provided service schema.
+ *
+ * To intercept HTTP requests, an interceptor needs a running {@link https://github.com/diego-aquino/zimic#httpinterceptorworker HttpInterceptorWorker}.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#httpinterceptor}
+ */
+
 export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
+  /**
+   * @returns The base URL used by the interceptor.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptorbaseurl}
+   */
   baseURL: () => string;
 
+  /**
+   * @returns A GET {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
+   * path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   get: HttpInterceptorMethodHandler<Schema, 'GET'>;
+
+  /**
+   * @returns A POST {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
+   * provided path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   post: HttpInterceptorMethodHandler<Schema, 'POST'>;
+
+  /**
+   * @returns A PATCH {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
+   * provided path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   patch: HttpInterceptorMethodHandler<Schema, 'PATCH'>;
+
+  /**
+   * @returns A PUT {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
+   * path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   put: HttpInterceptorMethodHandler<Schema, 'PUT'>;
+
+  /**
+   * @returns A DELETE {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
+   * provided path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   delete: HttpInterceptorMethodHandler<Schema, 'DELETE'>;
+
+  /**
+   * @returns A HEAD {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
+   * provided path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   head: HttpInterceptorMethodHandler<Schema, 'HEAD'>;
+
+  /**
+   * @returns An OPTIONS {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
+   * provided path. The path and method must be declared in the interceptor schema.
+   *
+   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   * as a type parameter to get type-inference and type-validation.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
+   */
   options: HttpInterceptorMethodHandler<Schema, 'OPTIONS'>;
 
+  /**
+   * Clears all of the {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} instances
+   * created by this interceptor. After calling this method, the interceptor will no longer intercept any requests until
+   * new mock responses are registered.
+   *
+   * This method is useful to reset the interceptor mocks between tests.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#interceptorclear}
+   */
   clear: () => void;
 }

--- a/packages/zimic/src/interceptor/http/interceptor/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/public.ts
@@ -5,7 +5,8 @@ import { HttpInterceptorSchema } from './schema';
  * Interceptor to handle matched HTTP requests and return mock responses. The methods, paths, status codes, parameters
  * and responses are statically-typed based on the provided service schema.
  *
- * To intercept HTTP requests, an interceptor needs a running {@link https://github.com/diego-aquino/zimic#httpinterceptorworker HttpInterceptorWorker}.
+ * To intercept HTTP requests, an interceptor needs a running
+ * {@link https://github.com/diego-aquino/zimic#httpinterceptorworker HttpInterceptorWorker}.
  *
  * @see {@link https://github.com/diego-aquino/zimic#httpinterceptor}
  */
@@ -13,84 +14,77 @@ import { HttpInterceptorSchema } from './schema';
 export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
   /**
    * @returns The base URL used by the interceptor.
-   *
    * @see {@link https://github.com/diego-aquino/zimic#interceptorbaseurl}
    */
   baseURL: () => string;
 
   /**
    * @returns A GET {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
-   * path. The path and method must be declared in the interceptor schema.
+   *   path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original
    *
+   *   Path as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   get: HttpInterceptorMethodHandler<Schema, 'GET'>;
 
   /**
-   * @returns A POST {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
-   * provided path. The path and method must be declared in the interceptor schema.
+   * @returns A POST {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
-   *
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   *   as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   post: HttpInterceptorMethodHandler<Schema, 'POST'>;
 
   /**
    * @returns A PATCH {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
-   * provided path. The path and method must be declared in the interceptor schema.
+   *   provided path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
-   *
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   *   as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   patch: HttpInterceptorMethodHandler<Schema, 'PATCH'>;
 
   /**
    * @returns A PUT {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
-   * path. The path and method must be declared in the interceptor schema.
+   *   path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
-   *
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   *   as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   put: HttpInterceptorMethodHandler<Schema, 'PUT'>;
 
   /**
    * @returns A DELETE {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
-   * provided path. The path and method must be declared in the interceptor schema.
+   *   provided path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
-   *
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   *   as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   delete: HttpInterceptorMethodHandler<Schema, 'DELETE'>;
 
   /**
-   * @returns A HEAD {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
-   * provided path. The path and method must be declared in the interceptor schema.
+   * @returns A HEAD {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
-   *
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   *   as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   head: HttpInterceptorMethodHandler<Schema, 'HEAD'>;
 
   /**
    * @returns An OPTIONS {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
-   * provided path. The path and method must be declared in the interceptor schema.
+   *   provided path. The path and method must be declared in the interceptor schema.
    *
-   * Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   * as a type parameter to get type-inference and type-validation.
-   *
+   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
+   *   as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   options: HttpInterceptorMethodHandler<Schema, 'OPTIONS'>;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/InvalidHttpInterceptorWorkerPlatform.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/InvalidHttpInterceptorWorkerPlatform.ts
@@ -1,8 +1,6 @@
 import { HttpInterceptorWorkerPlatform } from '../types/options';
 
-/**
- * Error thrown when an invalid worker platform is provided.
- */
+/** Error thrown when an invalid worker platform is provided. */
 class InvalidHttpInterceptorWorkerPlatform extends Error {
   constructor(platform: unknown) {
     const availablePlatforms = Object.values(HttpInterceptorWorkerPlatform);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/InvalidHttpInterceptorWorkerPlatform.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/InvalidHttpInterceptorWorkerPlatform.ts
@@ -1,5 +1,8 @@
 import { HttpInterceptorWorkerPlatform } from '../types/options';
 
+/**
+ * Error thrown when an invalid worker platform is provided.
+ */
 class InvalidHttpInterceptorWorkerPlatform extends Error {
   constructor(platform: unknown) {
     const availablePlatforms = Object.values(HttpInterceptorWorkerPlatform);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/NotStartedHttpInterceptorWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/NotStartedHttpInterceptorWorkerError.ts
@@ -1,3 +1,6 @@
+/**
+ * Error thrown when the worker is not running and it's not possible to declare mock responses.
+ */
 class NotStartedHttpInterceptorWorkerError extends Error {
   constructor() {
     super('Worker is not running. Did you forget to call `await worker.start()`?');

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/NotStartedHttpInterceptorWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/NotStartedHttpInterceptorWorkerError.ts
@@ -1,6 +1,4 @@
-/**
- * Error thrown when the worker is not running and it's not possible to declare mock responses.
- */
+/** Error thrown when the worker is not running and it's not possible to declare mock responses. */
 class NotStartedHttpInterceptorWorkerError extends Error {
   constructor() {
     super('Worker is not running. Did you forget to call `await worker.start()`?');

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
@@ -5,7 +5,8 @@ class UnregisteredServiceWorkerError extends Error {
     super(
       `Failed to register the browser service worker: ` +
         `script '${window.location.origin}/${SERVICE_WORKER_FILE_NAME}' not found.\n\n` +
-        'Did you forget to run "npx zimic browser init <public-directory>"?',
+        'Did you forget to run "npx zimic browser init <public-directory>"?\n\n' +
+        'Learn more at https://github.com/diego-aquino/zimic#browser-post-install.',
     );
     this.name = 'UnregisteredServiceWorkerError';
   }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
@@ -1,8 +1,6 @@
 import { SERVICE_WORKER_FILE_NAME } from '@/cli/browser/shared/constants';
 
-/**
- * Error thrown when the browser mock service worker is not found.
- */
+/** Error thrown when the browser mock service worker is not found. */
 class UnregisteredServiceWorkerError extends Error {
   constructor() {
     super(

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
@@ -1,5 +1,8 @@
 import { SERVICE_WORKER_FILE_NAME } from '@/cli/browser/shared/constants';
 
+/**
+ * Error thrown when the browser mock service worker is not found.
+ */
 class UnregisteredServiceWorkerError extends Error {
   constructor() {
     super(

--- a/packages/zimic/src/interceptor/http/interceptorWorker/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/factory.ts
@@ -2,6 +2,15 @@ import InternalHttpInterceptorWorker from './InternalHttpInterceptorWorker';
 import { HttpInterceptorWorkerOptions } from './types/options';
 import { HttpInterceptorWorker } from './types/public';
 
+/**
+ * Creates an HTTP interceptor worker.
+ *
+ * @param {HttpInterceptorWorkerOptions} options The options for the worker.
+ *
+ * @returns {HttpInterceptorWorker} The created HTTP interceptor worker.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#createhttpinterceptorworker}
+ */
 export function createHttpInterceptorWorker(options: HttpInterceptorWorkerOptions): HttpInterceptorWorker {
   return new InternalHttpInterceptorWorker(options);
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/factory.ts
@@ -6,9 +6,7 @@ import { HttpInterceptorWorker } from './types/public';
  * Creates an HTTP interceptor worker.
  *
  * @param {HttpInterceptorWorkerOptions} options The options for the worker.
- *
  * @returns {HttpInterceptorWorker} The created HTTP interceptor worker.
- *
  * @see {@link https://github.com/diego-aquino/zimic#createhttpinterceptorworker}
  */
 export function createHttpInterceptorWorker(options: HttpInterceptorWorkerOptions): HttpInterceptorWorker {

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/options.ts
@@ -5,9 +5,20 @@ enum HttpInterceptorWorkerPlatformEnum {
 
 type HttpInterceptorWorkerPlatformUnion = `${HttpInterceptorWorkerPlatformEnum}`;
 
-export type HttpInterceptorWorkerPlatform = HttpInterceptorWorkerPlatformUnion;
+/**
+ * The platform used by the worker (`browser` or `node`).
+ */
+export type HttpInterceptorWorkerPlatform = HttpInterceptorWorkerPlatformEnum | HttpInterceptorWorkerPlatformUnion;
 export const HttpInterceptorWorkerPlatform = HttpInterceptorWorkerPlatformEnum; // eslint-disable-line @typescript-eslint/no-redeclare
 
 export interface HttpInterceptorWorkerOptions {
+  /**
+   * The platform used by the worker (`browser` or `node`).
+   *
+   * When using `browser`, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting
+   * the worker. This initializes the mock service worker in your public directory.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#zimic-browser-init-publicdirectory}.
+   */
   platform: HttpInterceptorWorkerPlatform;
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/options.ts
@@ -5,9 +5,7 @@ enum HttpInterceptorWorkerPlatformEnum {
 
 type HttpInterceptorWorkerPlatformUnion = `${HttpInterceptorWorkerPlatformEnum}`;
 
-/**
- * The platform used by the worker (`browser` or `node`).
- */
+/** The platform used by the worker (`browser` or `node`). */
 export type HttpInterceptorWorkerPlatform = HttpInterceptorWorkerPlatformEnum | HttpInterceptorWorkerPlatformUnion;
 export const HttpInterceptorWorkerPlatform = HttpInterceptorWorkerPlatformEnum; // eslint-disable-line @typescript-eslint/no-redeclare
 
@@ -18,7 +16,7 @@ export interface HttpInterceptorWorkerOptions {
    * When using `browser`, make sure to run `npx zimic browser init <publicDirectory>` on your terminal before starting
    * the worker. This initializes the mock service worker in your public directory.
    *
-   * @see {@link https://github.com/diego-aquino/zimic#zimic-browser-init-publicdirectory}.
+   * @see {@link https://github.com/diego-aquino/zimic#zimic-browser-init-publicdirectory}
    */
   platform: HttpInterceptorWorkerPlatform;
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/public.ts
@@ -1,9 +1,48 @@
 import { HttpInterceptorWorkerPlatform } from './options';
 
+/**
+ * Worker responsible for intercepting HTTP requests and returning mock responses, compatible with browser and Node.js.
+ *
+ * To start intercepting requests, the worker must be started.
+ *
+ * All interceptors in a project can share the same worker.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#httpinterceptorworker}
+ */
 export interface HttpInterceptorWorker {
+  /**
+   * @returns The platform used by the worker (`browser` or `node`).
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#workerplatform}.
+   */
   platform: () => HttpInterceptorWorkerPlatform;
 
+  /**
+   * Starts the worker, allowing it to intercept HTTP requests.
+   *
+   * When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal
+   * before starting a worker. This initializes the mock service worker in your public directory.
+   *
+   * @throws {UnregisteredServiceWorkerError} When the worker is targeting a browser environment and the mock service
+   * worker is not registered.
+   *
+   * @throws {OtherHttpInterceptorWorkerRunningError} When another worker is already running.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#workerstart}.
+   */
   start: () => Promise<void>;
+
+  /**
+   * Stops the worker, preventing it from intercepting HTTP requests.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#workerstop}.
+   */
   stop: () => Promise<void>;
+
+  /**
+   * @returns Whether the worker is currently running and able to intercept HTTP requests.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#workerisrunning}.
+   */
   isRunning: () => boolean;
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/public.ts
@@ -1,7 +1,8 @@
 import { HttpInterceptorWorkerPlatform } from './options';
 
 /**
- * Worker used by interceptors to intercept HTTP requests and return mock responses. To start intercepting requests, the worker must be started.
+ * Worker used by interceptors to intercept HTTP requests and return mock responses. To start intercepting requests, the
+ * worker must be started.
  *
  * In a project, all interceptors can share the same worker.
  *
@@ -10,8 +11,7 @@ import { HttpInterceptorWorkerPlatform } from './options';
 export interface HttpInterceptorWorker {
   /**
    * @returns The platform used by the worker (`browser` or `node`).
-   *
-   * @see {@link https://github.com/diego-aquino/zimic#workerplatform}.
+   * @see {@link https://github.com/diego-aquino/zimic#workerplatform}
    */
   platform: () => HttpInterceptorWorkerPlatform;
 
@@ -22,25 +22,22 @@ export interface HttpInterceptorWorker {
    * before starting the worker. This initializes the mock service worker in your public directory.
    *
    * @throws {UnregisteredServiceWorkerError} When the worker is targeting a browser environment and the mock service
-   * worker is not registered.
-   *
+   *   worker is not registered.
    * @throws {OtherHttpInterceptorWorkerRunningError} When another worker is already running.
-   *
-   * @see {@link https://github.com/diego-aquino/zimic#workerstart}.
+   * @see {@link https://github.com/diego-aquino/zimic#workerstart}
    */
   start: () => Promise<void>;
 
   /**
    * Stops the worker, preventing it from being used by interceptors.
    *
-   * @see {@link https://github.com/diego-aquino/zimic#workerstop}.
+   * @see {@link https://github.com/diego-aquino/zimic#workerstop}
    */
   stop: () => Promise<void>;
 
   /**
    * @returns Whether the worker is currently running and ready to use.
-   *
-   * @see {@link https://github.com/diego-aquino/zimic#workerisrunning}.
+   * @see {@link https://github.com/diego-aquino/zimic#workerisrunning}
    */
   isRunning: () => boolean;
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/public.ts
@@ -1,11 +1,9 @@
 import { HttpInterceptorWorkerPlatform } from './options';
 
 /**
- * Worker responsible for intercepting HTTP requests and returning mock responses, compatible with browser and Node.js.
+ * Worker used by interceptors to intercept HTTP requests and return mock responses. To start intercepting requests, the worker must be started.
  *
- * To start intercepting requests, the worker must be started.
- *
- * All interceptors in a project can share the same worker.
+ * In a project, all interceptors can share the same worker.
  *
  * @see {@link https://github.com/diego-aquino/zimic#httpinterceptorworker}
  */
@@ -18,10 +16,10 @@ export interface HttpInterceptorWorker {
   platform: () => HttpInterceptorWorkerPlatform;
 
   /**
-   * Starts the worker, allowing it to intercept HTTP requests.
+   * Starts the worker, allowing it to be used by interceptors.
    *
    * When targeting a browser environment, make sure to run `npx zimic browser init <publicDirectory>` on your terminal
-   * before starting a worker. This initializes the mock service worker in your public directory.
+   * before starting the worker. This initializes the mock service worker in your public directory.
    *
    * @throws {UnregisteredServiceWorkerError} When the worker is targeting a browser environment and the mock service
    * worker is not registered.
@@ -33,14 +31,14 @@ export interface HttpInterceptorWorker {
   start: () => Promise<void>;
 
   /**
-   * Stops the worker, preventing it from intercepting HTTP requests.
+   * Stops the worker, preventing it from being used by interceptors.
    *
    * @see {@link https://github.com/diego-aquino/zimic#workerstop}.
    */
   stop: () => Promise<void>;
 
   /**
-   * @returns Whether the worker is currently running and able to intercept HTTP requests.
+   * @returns Whether the worker is currently running and ready to use.
    *
    * @see {@link https://github.com/diego-aquino/zimic#workerisrunning}.
    */

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/requests.ts
@@ -10,6 +10,9 @@ import { PossiblePromise } from '@/types/utils';
 export type HttpWorker = BrowserMSWWorker | NodeMSWWorker;
 export { BrowserMSWWorker as BrowserHttpWorker, NodeMSWWorker as NodeHttpWorker };
 
+/**
+ * The default body type (JSON) for HTTP requests and responses.
+ */
 export type DefaultBody = JSONValue;
 
 export type HttpRequestHandlerContext<Body extends DefaultBody = DefaultBody> = ResponseResolverInfo<
@@ -17,10 +20,16 @@ export type HttpRequestHandlerContext<Body extends DefaultBody = DefaultBody> = 
   Body
 >;
 
+/**
+ * An HTTP request with a strictly-typed JSON body.
+ */
 export interface HttpRequest<StrictBody extends DefaultBody = DefaultBody> extends Request {
   json: () => Promise<StrictBody>;
 }
 
+/**
+ * An HTTP response with a strictly-typed JSON body and status code.
+ */
 export interface HttpResponse<StrictBody extends DefaultBody = DefaultBody, StatusCode extends number = number>
   extends Response {
   status: StatusCode;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/requests.ts
@@ -10,9 +10,7 @@ import { PossiblePromise } from '@/types/utils';
 export type HttpWorker = BrowserMSWWorker | NodeMSWWorker;
 export { BrowserMSWWorker as BrowserHttpWorker, NodeMSWWorker as NodeHttpWorker };
 
-/**
- * The default body type (JSON) for HTTP requests and responses.
- */
+/** The default body type (JSON) for HTTP requests and responses. */
 export type DefaultBody = JSONValue;
 
 export type HttpRequestHandlerContext<Body extends DefaultBody = DefaultBody> = ResponseResolverInfo<
@@ -20,16 +18,12 @@ export type HttpRequestHandlerContext<Body extends DefaultBody = DefaultBody> = 
   Body
 >;
 
-/**
- * An HTTP request with a strictly-typed JSON body.
- */
+/** An HTTP request with a strictly-typed JSON body. */
 export interface HttpRequest<StrictBody extends DefaultBody = DefaultBody> extends Request {
   json: () => Promise<StrictBody>;
 }
 
-/**
- * An HTTP response with a strictly-typed JSON body and status code.
- */
+/** An HTTP response with a strictly-typed JSON body and status code. */
 export interface HttpResponse<StrictBody extends DefaultBody = DefaultBody, StatusCode extends number = number>
   extends Response {
   status: StatusCode;

--- a/packages/zimic/src/interceptor/http/requestTracker/InternalHttpRequestTracker.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/InternalHttpRequestTracker.ts
@@ -50,15 +50,15 @@ class InternalHttpRequestTracker<
   respond<
     NewStatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
   >(
-    declarationOrCreateDeclaration:
+    declaration:
       | HttpRequestTrackerResponseDeclaration<Default<Schema[Path][Method]>, NewStatusCode>
       | HttpRequestTrackerResponseDeclarationFactory<Default<Schema[Path][Method]>, NewStatusCode>,
   ): InternalHttpRequestTracker<Schema, Method, Path, NewStatusCode> {
     const newThis = this as unknown as InternalHttpRequestTracker<Schema, Method, Path, NewStatusCode>;
 
-    newThis.createResponseDeclaration = this.isResponseDeclarationFactory<NewStatusCode>(declarationOrCreateDeclaration)
-      ? declarationOrCreateDeclaration
-      : () => declarationOrCreateDeclaration;
+    newThis.createResponseDeclaration = this.isResponseDeclarationFactory<NewStatusCode>(declaration)
+      ? declaration
+      : () => declaration;
 
     newThis.interceptedRequests = [];
 

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -13,9 +13,11 @@ import {
 } from './requests';
 
 /**
- * Tracker for intercepted HTTP requests, supporting response declarations to return for matched intercepted requests.
+ * HTTP request trackers allow declaring responses to return for matched intercepted requests. They also keep track of
+ * the intercepted requests and their responses, allowing checks about how many requests your application made and with
+ * which parameters.
  *
- * When multiple trackers of the same interceptor match the same method and route, the **last** tracker created with
+ * When multiple trackers of the same interceptor match the same method and route, the *last* tracker created with
  * {@link https://github.com/diego-aquino/zimic#interceptormethodpath `interceptor.<method>(path)`} will be used.
  *
  * @see {@link https://github.com/diego-aquino/zimic#httprequesttracker}
@@ -37,7 +39,7 @@ export interface HttpRequestTracker<
 
   /**
    * @returns The path that matches this tracker. The base URL of the interceptor is not included, but it is used when
-   * checking for intercepted request matches.
+   * matching requests.
    *
    * @see {@link https://github.com/diego-aquino/zimic#trackerpath}
    */

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -12,6 +12,14 @@ import {
   TrackedHttpInterceptorRequest,
 } from './requests';
 
+/**
+ * Tracker for intercepted HTTP requests, supporting response declarations to return for matched intercepted requests.
+ *
+ * When multiple trackers of the same interceptor match the same method and route, the **last** tracker created with
+ * {@link https://github.com/diego-aquino/zimic#interceptormethodpath `interceptor.<method>(path)`} will be used.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#httprequesttracker}
+ */
 export interface HttpRequestTracker<
   Schema extends HttpInterceptorSchema,
   Method extends HttpInterceptorSchemaMethod<Schema>,
@@ -20,18 +28,56 @@ export interface HttpRequestTracker<
     Default<Default<Schema[Path][Method]>['response']>
   > = never,
 > {
+  /**
+   * @returns The method that matches this tracker.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#trackermethod}
+   */
   method: () => Method;
+
+  /**
+   * @returns The path that matches this tracker. The base URL of the interceptor is not included, but it is used when
+   * checking for intercepted request matches.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#trackerpath}
+   */
   path: () => Path;
 
+  /**
+   * Declares a response to return for matched intercepted requests.
+   *
+   * When the tracker matches a request, it will respond with the given declaration. The response type is statically
+   * validated against the schema of the interceptor.
+   *
+   * @param declaration The response declaration or a factory to create it.
+   *
+   * @returns The same tracker, now including type information about the response declaration based on the
+   * specified status code.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#trackerrespond}
+   */
   respond: <
     StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
   >(
-    declarationOrCreateDeclaration:
+    declaration:
       | HttpRequestTrackerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>
       | HttpRequestTrackerResponseDeclarationFactory<Default<Schema[Path][Method]>, StatusCode>,
   ) => HttpRequestTracker<Schema, Method, Path, StatusCode>;
 
+  /**
+   * Clears any declared response and makes the tracker stop matching intercepted requests. The next tracker, created
+   * before this one, that matches the same method and path will be used if present. If not, the requests of the method
+   * and path will not be intercepted.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#trackerbypass}
+   */
   bypass: () => HttpRequestTracker<Schema, Method, Path, StatusCode>;
 
+  /**
+   * @returns The intercepted requests that matched this tracker, along with the responses returned to each of them.
+   * This is useful for testing that the correct requests were made by your application.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#trackerrequests}
+   */
   requests: () => readonly TrackedHttpInterceptorRequest<Default<Schema[Path][Method]>, StatusCode>[];
 }

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -17,7 +17,7 @@ import {
  * the intercepted requests and their responses, allowing checks about how many requests your application made and with
  * which parameters.
  *
- * When multiple trackers of the same interceptor match the same method and route, the *last* tracker created with
+ * When multiple trackers of the same interceptor match the same method and route, the _last_ tracker created with
  * {@link https://github.com/diego-aquino/zimic#interceptormethodpath `interceptor.<method>(path)`} will be used.
  *
  * @see {@link https://github.com/diego-aquino/zimic#httprequesttracker}
@@ -32,15 +32,13 @@ export interface HttpRequestTracker<
 > {
   /**
    * @returns The method that matches this tracker.
-   *
    * @see {@link https://github.com/diego-aquino/zimic#trackermethod}
    */
   method: () => Method;
 
   /**
    * @returns The path that matches this tracker. The base URL of the interceptor is not included, but it is used when
-   * matching requests.
-   *
+   *   matching requests.
    * @see {@link https://github.com/diego-aquino/zimic#trackerpath}
    */
   path: () => Path;
@@ -52,10 +50,8 @@ export interface HttpRequestTracker<
    * validated against the schema of the interceptor.
    *
    * @param declaration The response declaration or a factory to create it.
-   *
-   * @returns The same tracker, now including type information about the response declaration based on the
-   * specified status code.
-   *
+   * @returns The same tracker, now including type information about the response declaration based on the specified
+   *   status code.
    * @see {@link https://github.com/diego-aquino/zimic#trackerrespond}
    */
   respond: <
@@ -77,8 +73,7 @@ export interface HttpRequestTracker<
 
   /**
    * @returns The intercepted requests that matched this tracker, along with the responses returned to each of them.
-   * This is useful for testing that the correct requests were made by your application.
-   *
+   *   This is useful for testing that the correct requests were made by your application.
    * @see {@link https://github.com/diego-aquino/zimic#trackerrequests}
    */
   requests: () => readonly TrackedHttpInterceptorRequest<Default<Schema[Path][Method]>, StatusCode>[];

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -3,10 +3,8 @@ import NotStartedHttpInterceptorWorkerError from './http/interceptorWorker/error
 import UnregisteredServiceWorkerError from './http/interceptorWorker/errors/UnregisteredServiceWorkerError';
 
 export type { HttpInterceptorWorker } from './http/interceptorWorker/types/public';
-export type {
-  HttpInterceptorWorkerOptions,
-  HttpInterceptorWorkerPlatform,
-} from './http/interceptorWorker/types/options';
+export type { HttpInterceptorWorkerOptions } from './http/interceptorWorker/types/options';
+export { HttpInterceptorWorkerPlatform } from './http/interceptorWorker/types/options';
 export type { DefaultBody, HttpRequest, HttpResponse } from './http/interceptorWorker/types/requests';
 
 export { createHttpInterceptorWorker } from './http/interceptorWorker/factory';
@@ -22,8 +20,6 @@ export type {
 } from './http/requestTracker/types/requests';
 
 export type { HttpRequestTracker } from './http/requestTracker/types/public';
-
-export type { HttpInterceptorMethodHandler } from './http/interceptor/types/handlers';
 
 export type { HttpInterceptorOptions } from './http/interceptor/types/options';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       prettier:
         specifier: ^3.2.0
         version: 3.2.0
+      prettier-plugin-jsdoc:
+        specifier: ^1.3.0
+        version: 1.3.0(prettier@3.2.0)
       prettier-plugin-sh:
         specifier: ^0.13.1
         version: 0.13.1(prettier@3.2.0)
@@ -1116,6 +1119,12 @@ packages:
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
     dev: true
 
+  /@types/debug@4.1.12:
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+    dependencies:
+      '@types/ms': 0.7.34
+    dev: true
+
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
@@ -1133,12 +1142,22 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: false
 
+  /@types/mdast@4.0.3:
+    resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: true
+
   /@types/methods@1.1.4:
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
     dev: true
 
   /@types/minimist@1.2.5:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  /@types/ms@0.7.34:
+    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
+    dev: true
 
   /@types/node-fetch@2.6.10:
     resolution: {integrity: sha512-PPpPK6F9ALFTn59Ka3BaL+qGuipRfxNE8qVgkp0bVixeiR2c2/L+IVOiBdu9JhhT22sWnQEp6YyHGI2b2+CMcA==}
@@ -1174,6 +1193,10 @@ packages:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 18.19.6
+    dev: true
+
+  /@types/unist@3.0.2:
+    resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: true
 
   /@types/yargs-parser@21.0.3:
@@ -1629,6 +1652,10 @@ packages:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
 
+  /binary-searching@2.0.5:
+    resolution: {integrity: sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==}
+    dev: true
+
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -1749,6 +1776,10 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  /character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: true
+
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
     dev: false
@@ -1851,6 +1882,11 @@ packages:
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
     dev: true
 
   /compare-func@2.0.0:
@@ -1988,6 +2024,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /decode-named-character-reference@1.0.2:
+    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+    dependencies:
+      character-entities: 2.0.2
+    dev: true
+
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
@@ -2025,6 +2067,17 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
 
   /dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -3568,6 +3621,31 @@ packages:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
     dev: false
 
+  /mdast-util-from-markdown@2.0.0:
+    resolution: {integrity: sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==}
+    dependencies:
+      '@types/mdast': 4.0.3
+      '@types/unist': 3.0.2
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.1
+      micromark-util-decode-string: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+    dependencies:
+      '@types/mdast': 4.0.3
+    dev: true
+
   /meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -3600,6 +3678,181 @@ packages:
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /micromark-core-commonmark@2.0.0:
+    resolution: {integrity: sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.0
+      micromark-factory-label: 2.0.0
+      micromark-factory-space: 2.0.0
+      micromark-factory-title: 2.0.0
+      micromark-factory-whitespace: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-classify-character: 2.0.0
+      micromark-util-html-tag-name: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-factory-destination@2.0.0:
+    resolution: {integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==}
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-factory-label@2.0.0:
+    resolution: {integrity: sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-factory-space@2.0.0:
+    resolution: {integrity: sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==}
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-factory-title@2.0.0:
+    resolution: {integrity: sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==}
+    dependencies:
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-factory-whitespace@2.0.0:
+    resolution: {integrity: sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==}
+    dependencies:
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-util-character@2.1.0:
+    resolution: {integrity: sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-util-chunked@2.0.0:
+    resolution: {integrity: sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+    dev: true
+
+  /micromark-util-classify-character@2.0.0:
+    resolution: {integrity: sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==}
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-util-combine-extensions@2.0.0:
+    resolution: {integrity: sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==}
+    dependencies:
+      micromark-util-chunked: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-util-decode-numeric-character-reference@2.0.1:
+    resolution: {integrity: sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+    dev: true
+
+  /micromark-util-decode-string@2.0.0:
+    resolution: {integrity: sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 2.1.0
+      micromark-util-decode-numeric-character-reference: 2.0.1
+      micromark-util-symbol: 2.0.0
+    dev: true
+
+  /micromark-util-encode@2.0.0:
+    resolution: {integrity: sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==}
+    dev: true
+
+  /micromark-util-html-tag-name@2.0.0:
+    resolution: {integrity: sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==}
+    dev: true
+
+  /micromark-util-normalize-identifier@2.0.0:
+    resolution: {integrity: sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==}
+    dependencies:
+      micromark-util-symbol: 2.0.0
+    dev: true
+
+  /micromark-util-resolve-all@2.0.0:
+    resolution: {integrity: sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==}
+    dependencies:
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-util-sanitize-uri@2.0.0:
+    resolution: {integrity: sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==}
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-encode: 2.0.0
+      micromark-util-symbol: 2.0.0
+    dev: true
+
+  /micromark-util-subtokenize@2.0.0:
+    resolution: {integrity: sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    dev: true
+
+  /micromark-util-symbol@2.0.0:
+    resolution: {integrity: sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==}
+    dev: true
+
+  /micromark-util-types@2.0.0:
+    resolution: {integrity: sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==}
+    dev: true
+
+  /micromark@4.0.0:
+    resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.3.4
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.0
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-combine-extensions: 2.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.1
+      micromark-util-encode: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /micromatch@4.0.5:
@@ -4091,6 +4344,20 @@ packages:
     dependencies:
       fast-diff: 1.3.0
     dev: false
+
+  /prettier-plugin-jsdoc@1.3.0(prettier@3.2.0):
+    resolution: {integrity: sha512-cQm8xIa0fN9ieJFMXACQd6JPycl+8ouOijAqUqu44EF/s4fXL3Wi9sKXuEaodsEWgCN42Xby/bNhqgM1iWx4uw==}
+    engines: {node: '>=14.13.1 || >=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.0
+    dependencies:
+      binary-searching: 2.0.5
+      comment-parser: 1.4.1
+      mdast-util-from-markdown: 2.0.0
+      prettier: 3.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /prettier-plugin-sh@0.13.1(prettier@3.2.0):
     resolution: {integrity: sha512-ytMcl1qK4s4BOFGvsc9b0+k9dYECal7U29bL/ke08FEUsF/JLN0j6Peo0wUkFDG4y2UHLMhvpyd6Sd3zDXe/eg==}
@@ -5013,6 +5280,12 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  /unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+    dependencies:
+      '@types/unist': 3.0.2
+    dev: true
 
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}


### PR DESCRIPTION
- docs: create initial `README.md` and `CONTRIBUTING.md`
- docs(#zimic): add browser post install link to unregistered worker error
- docs(#zimic): add api documentation as jsdoc
- docs(#zimic): sync `README.md` with JSDoc API documentation
- test(zimic-test-client): remove check to exported internal type
- docs: improve `README.md`
- docs: improve `README.md`
- docs: add `Why` section to `README.md`
- docs: add basic usage section to `README.md`
- docs: add interceptor schema examples
- docs: remove `Why` section for now
- docs: improve overall `README.md`
- style: enable prettier markdown formatting
- style: format jsdoc comments using prettier

Closes #19, closes #22.
