### PR TITLE
refactor: improve internal class names

### DIFF
--- a/apps/zimic-test-client/tsconfig.json
+++ b/apps/zimic-test-client/tsconfig.json
@@ -9,5 +9,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.mts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules"]
 }

--- a/apps/zimic-test-client/turbo.json
+++ b/apps/zimic-test-client/turbo.json
@@ -2,11 +2,6 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "pipeline": {
-    "build": {
-      "inputs": ["src/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts", ".swcrc"],
-      "outputs": ["dist/**"]
-    },
-
     "deps:init-zimic": {
       "dependsOn": ["^build"],
       "inputs": ["package.json"],
@@ -15,7 +10,7 @@
 
     "test:turbo": {
       "dependsOn": ["^build", "deps:init-zimic"],
-      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts", ".swcrc", "jest.config.js"]
+      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts"]
     },
 
     "lint:turbo": {

--- a/packages/release/turbo.json
+++ b/packages/release/turbo.json
@@ -8,7 +8,7 @@
     },
 
     "test:turbo": {
-      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts", ".swcrc", "jest.config.js"]
+      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts"]
     },
 
     "lint:turbo": {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -1,8 +1,8 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
@@ -14,7 +14,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
 
   const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
 
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   beforeAll(async () => {
@@ -43,7 +43,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
         status: 200,
         body: users[0],
       });
-      expect(deletionTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(deletionTracker).toBeInstanceOf(HttpRequestTracker);
 
       const deletionRequests = deletionTracker.requests();
       expect(deletionRequests).toHaveLength(0);
@@ -134,7 +134,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
         status: 200,
         body: users[0],
       });
-      expect(genericDeletionTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericDeletionTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericDeletionRequests = genericDeletionTracker.requests();
       expect(genericDeletionRequests).toHaveLength(0);
@@ -164,7 +164,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
         status: 200,
         body: users[0],
       });
-      expect(specificDeletionTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificDeletionTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificDeletionRequests = specificDeletionTracker.requests();
       expect(specificDeletionRequests).toHaveLength(0);
@@ -213,7 +213,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
       await expect(deletionPromise).rejects.toThrowError();
 
       const deletionTrackerWithoutResponse = interceptor.delete('/users');
-      expect(deletionTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(deletionTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const deletionRequestsWithoutResponse = deletionTrackerWithoutResponse.requests();
       expect(deletionRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -1,8 +1,8 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
@@ -14,7 +14,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
 
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   beforeAll(async () => {
@@ -43,7 +43,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: users,
       });
-      expect(listTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(listTracker).toBeInstanceOf(HttpRequestTracker);
 
       const listRequests = listTracker.requests();
       expect(listRequests).toHaveLength(0);
@@ -85,7 +85,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: [{ name: userName }],
       }));
-      expect(listTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(listTracker).toBeInstanceOf(HttpRequestTracker);
 
       const listRequests = listTracker.requests();
       expect(listRequests).toHaveLength(0);
@@ -128,7 +128,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: users[0],
       });
-      expect(genericGetTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericGetTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericGetRequests = genericGetTracker.requests();
       expect(genericGetRequests).toHaveLength(0);
@@ -158,7 +158,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: users[0],
       });
-      expect(specificGetTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificGetTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificGetRequests = specificGetTracker.requests();
       expect(specificGetRequests).toHaveLength(0);
@@ -201,7 +201,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
       await expect(fetchPromise).rejects.toThrowError();
 
       const listTrackerWithoutResponse = interceptor.get('/users');
-      expect(listTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(listTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const listRequestsWithoutResponse = listTrackerWithoutResponse.requests();
       expect(listRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -1,14 +1,14 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareHeadHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   beforeAll(async () => {
@@ -36,7 +36,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       const headTracker = interceptor.head('/users').respond({
         status: 200,
       });
-      expect(headTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(headTracker).toBeInstanceOf(HttpRequestTracker);
 
       const headRequests = headTracker.requests();
       expect(headRequests).toHaveLength(0);
@@ -72,7 +72,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       const headTracker = interceptor.head('/users').respond(() => ({
         status: 200,
       }));
-      expect(headTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(headTracker).toBeInstanceOf(HttpRequestTracker);
 
       const headRequests = headTracker.requests();
       expect(headRequests).toHaveLength(0);
@@ -111,7 +111,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       const genericHeadTracker = interceptor.head('/users/:id').respond({
         status: 200,
       });
-      expect(genericHeadTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericHeadTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericHeadRequests = genericHeadTracker.requests();
       expect(genericHeadRequests).toHaveLength(0);
@@ -137,7 +137,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       const specificHeadTracker = interceptor.head<'/users/:id'>(`/users/${1}`).respond({
         status: 200,
       });
-      expect(specificHeadTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificHeadTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificHeadRequests = specificHeadTracker.requests();
       expect(specificHeadRequests).toHaveLength(0);
@@ -177,7 +177,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       await expect(fetchPromise).rejects.toThrowError();
 
       const headTrackerWithoutResponse = interceptor.head('/users');
-      expect(headTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(headTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const headRequestsWithoutResponse = headTrackerWithoutResponse.requests();
       expect(headRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -1,14 +1,14 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   interface Filters {
@@ -40,7 +40,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       const optionsTracker = interceptor.options('/filters').respond({
         status: 200,
       });
-      expect(optionsTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(optionsTracker).toBeInstanceOf(HttpRequestTracker);
 
       const optionsRequests = optionsTracker.requests();
       expect(optionsRequests).toHaveLength(0);
@@ -80,7 +80,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
           status: 200,
         };
       });
-      expect(optionsTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(optionsTracker).toBeInstanceOf(HttpRequestTracker);
 
       const optionsRequests = optionsTracker.requests();
       expect(optionsRequests).toHaveLength(0);
@@ -125,7 +125,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       const genericOptionsTracker = interceptor.options('/filters/:id').respond({
         status: 200,
       });
-      expect(genericOptionsTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericOptionsTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericOptionsRequests = genericOptionsTracker.requests();
       expect(genericOptionsRequests).toHaveLength(0);
@@ -151,7 +151,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       const specificOptionsTracker = interceptor.options<'/filters/:id'>(`/filters/${1}`).respond({
         status: 200,
       });
-      expect(specificOptionsTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificOptionsTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificOptionsRequests = specificOptionsTracker.requests();
       expect(specificOptionsRequests).toHaveLength(0);
@@ -191,7 +191,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       await expect(fetchPromise).rejects.toThrowError();
 
       const optionsTrackerWithoutResponse = interceptor.options('/filters');
-      expect(optionsTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(optionsTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const optionsRequestsWithoutResponse = optionsTrackerWithoutResponse.requests();
       expect(optionsRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -1,14 +1,14 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   interface User {
@@ -43,7 +43,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         status: 200,
         body: users[0],
       });
-      expect(updateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
@@ -90,7 +90,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
           },
         };
       });
-      expect(updateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
@@ -135,7 +135,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         status: 200,
         body: users[0],
       });
-      expect(genericUpdateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericUpdateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericUpdateRequests = genericUpdateTracker.requests();
       expect(genericUpdateRequests).toHaveLength(0);
@@ -165,7 +165,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         status: 200,
         body: users[0],
       });
-      expect(specificUpdateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificUpdateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificUpdateRequests = specificUpdateTracker.requests();
       expect(specificUpdateRequests).toHaveLength(0);
@@ -214,7 +214,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       await expect(updatePromise).rejects.toThrowError();
 
       const updateTrackerWithoutResponse = interceptor.patch('/users');
-      expect(updateTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(updateTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequestsWithoutResponse = updateTrackerWithoutResponse.requests();
       expect(updateRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -1,14 +1,14 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePostHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   interface User {
@@ -43,7 +43,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
         status: 201,
         body: users[0],
       });
-      expect(creationTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(creationTracker).toBeInstanceOf(HttpRequestTracker);
 
       const creationRequests = creationTracker.requests();
       expect(creationRequests).toHaveLength(0);
@@ -90,7 +90,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
           },
         };
       });
-      expect(creationTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(creationTracker).toBeInstanceOf(HttpRequestTracker);
 
       const creationRequests = creationTracker.requests();
       expect(creationRequests).toHaveLength(0);
@@ -135,7 +135,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
         status: 201,
         body: users[0],
       });
-      expect(genericCreationTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericCreationTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericCreationRequests = genericCreationTracker.requests();
       expect(genericCreationRequests).toHaveLength(0);
@@ -165,7 +165,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
         status: 201,
         body: users[0],
       });
-      expect(specificCreationTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificCreationTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificCreationRequests = specificCreationTracker.requests();
       expect(specificCreationRequests).toHaveLength(0);
@@ -214,7 +214,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
       await expect(creationPromise).rejects.toThrowError();
 
       const creationTrackerWithoutResponse = interceptor.post('/users');
-      expect(creationTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(creationTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const creationRequestsWithoutResponse = creationTrackerWithoutResponse.requests();
       expect(creationRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -1,14 +1,14 @@
 import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest';
 
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
-import InternalHttpRequestTracker from '@/interceptor/http/requestTracker/InternalHttpRequestTracker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
+import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePutHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
-  const worker = createHttpInterceptorWorker({ platform }) as InternalHttpInterceptorWorker;
+  const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 
   interface User {
@@ -43,7 +43,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: users[0],
       });
-      expect(updateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
@@ -90,7 +90,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
           },
         };
       });
-      expect(updateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
@@ -135,7 +135,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: users[0],
       });
-      expect(genericUpdateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(genericUpdateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const genericUpdateRequests = genericUpdateTracker.requests();
       expect(genericUpdateRequests).toHaveLength(0);
@@ -165,7 +165,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         status: 200,
         body: users[0],
       });
-      expect(specificUpdateTracker).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(specificUpdateTracker).toBeInstanceOf(HttpRequestTracker);
 
       const specificUpdateRequests = specificUpdateTracker.requests();
       expect(specificUpdateRequests).toHaveLength(0);
@@ -214,7 +214,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       await expect(updatePromise).rejects.toThrowError();
 
       const updateTrackerWithoutResponse = interceptor.put('/users');
-      expect(updateTrackerWithoutResponse).toBeInstanceOf(InternalHttpRequestTracker);
+      expect(updateTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequestsWithoutResponse = updateTrackerWithoutResponse.requests();
       expect(updateRequestsWithoutResponse).toHaveLength(0);

--- a/packages/zimic/src/interceptor/http/interceptor/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/factory.ts
@@ -1,6 +1,6 @@
-import InternalHttpInterceptor from './InternalHttpInterceptor';
+import HttpInterceptor from './HttpInterceptor';
 import { HttpInterceptorOptions } from './types/options';
-import { HttpInterceptor } from './types/public';
+import { HttpInterceptor as PublicHttpInterceptor } from './types/public';
 import { HttpInterceptorSchema } from './types/schema';
 
 /**
@@ -12,6 +12,6 @@ import { HttpInterceptorSchema } from './types/schema';
  */
 export function createHttpInterceptor<Schema extends HttpInterceptorSchema>(
   options: HttpInterceptorOptions,
-): HttpInterceptor<Schema> {
-  return new InternalHttpInterceptor<Schema>(options);
+): PublicHttpInterceptor<Schema> {
+  return new HttpInterceptor<Schema>(options);
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -27,7 +27,7 @@ import NotStartedHttpInterceptorWorkerError from './errors/NotStartedHttpInterce
 import OtherHttpInterceptorWorkerRunningError from './errors/OtherHttpInterceptorWorkerRunningError';
 import UnregisteredServiceWorkerError from './errors/UnregisteredServiceWorkerError';
 import { HttpInterceptorWorkerOptions, HttpInterceptorWorkerPlatform } from './types/options';
-import { HttpInterceptorWorker } from './types/public';
+import { HttpInterceptorWorker as PublicHttpInterceptorWorker } from './types/public';
 import {
   DefaultBody,
   BrowserHttpWorker,
@@ -38,8 +38,8 @@ import {
   NodeHttpWorker,
 } from './types/requests';
 
-class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
-  private static runningInstance?: InternalHttpInterceptorWorker;
+class HttpInterceptorWorker implements PublicHttpInterceptorWorker {
+  private static runningInstance?: HttpInterceptorWorker;
 
   private _platform: HttpInterceptorWorkerPlatform;
   private _internalWorker?: HttpWorker;
@@ -105,7 +105,7 @@ class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
   }
 
   async start() {
-    if (InternalHttpInterceptorWorker.runningInstance && InternalHttpInterceptorWorker.runningInstance !== this) {
+    if (HttpInterceptorWorker.runningInstance && HttpInterceptorWorker.runningInstance !== this) {
       throw new OtherHttpInterceptorWorkerRunningError();
     }
 
@@ -123,7 +123,7 @@ class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
     }
 
     this._isRunning = true;
-    InternalHttpInterceptorWorker.runningInstance = this;
+    HttpInterceptorWorker.runningInstance = this;
   }
 
   private async startInBrowser(internalWorker: BrowserHttpWorker, sharedOptions: MSWWorkerSharedOptions) {
@@ -161,7 +161,7 @@ class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
     this.clearHandlers();
 
     this._isRunning = false;
-    InternalHttpInterceptorWorker.runningInstance = undefined;
+    HttpInterceptorWorker.runningInstance = undefined;
   }
 
   private stopInBrowser(internalWorker: BrowserHttpWorker) {
@@ -245,14 +245,14 @@ class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
 
     const parsedRequest = new Proxy(rawRequest as unknown as HttpInterceptorRequest<MethodSchema>, {
       has(target, property: keyof HttpInterceptorRequest<MethodSchema>) {
-        if (InternalHttpInterceptorWorker.isHiddenRequestProperty(property)) {
+        if (HttpInterceptorWorker.isHiddenRequestProperty(property)) {
           return false;
         }
         return Reflect.has(target, property);
       },
 
       get(target, property: keyof HttpInterceptorRequest<MethodSchema>) {
-        if (InternalHttpInterceptorWorker.isHiddenRequestProperty(property)) {
+        if (HttpInterceptorWorker.isHiddenRequestProperty(property)) {
           return undefined;
         }
         if (property === 'body') {
@@ -281,14 +281,14 @@ class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
 
     const parsedRequest = new Proxy(rawResponse as unknown as HttpInterceptorResponse<MethodSchema, StatusCode>, {
       has(target, property: keyof HttpInterceptorResponse<MethodSchema, StatusCode>) {
-        if (InternalHttpInterceptorWorker.isHiddenResponseProperty(property)) {
+        if (HttpInterceptorWorker.isHiddenResponseProperty(property)) {
           return false;
         }
         return Reflect.has(target, property);
       },
 
       get(target, property: keyof HttpInterceptorResponse<MethodSchema, StatusCode>) {
-        if (InternalHttpInterceptorWorker.isHiddenResponseProperty(property)) {
+        if (HttpInterceptorWorker.isHiddenResponseProperty(property)) {
           return undefined;
         }
         if (property === 'body') {
@@ -320,4 +320,4 @@ class InternalHttpInterceptorWorker implements HttpInterceptorWorker {
   }
 }
 
-export default InternalHttpInterceptorWorker;
+export default HttpInterceptorWorker;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browser.test.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browser.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import MismatchedHttpInterceptorWorkerPlatform from '../errors/MismatchedHttpInterceptorWorkerPlatform';
-import InternalHttpInterceptorWorker from '../InternalHttpInterceptorWorker';
+import { createHttpInterceptorWorker } from '../factory';
 import { HttpInterceptorWorkerPlatform } from '../types/options';
 import { declareSharedHttpInterceptorWorkerTests } from './shared/workerTests';
 
@@ -16,7 +16,7 @@ describe('HttpInterceptorWorker (browser)', () => {
     const mismatchedPlatform: HttpInterceptorWorkerPlatform = 'node';
     expect(mismatchedPlatform).not.toBe(platform);
 
-    const interceptorWorker = new InternalHttpInterceptorWorker({
+    const interceptorWorker = createHttpInterceptorWorker({
       platform: mismatchedPlatform,
     });
     expect(interceptorWorker.platform()).toBe(mismatchedPlatform);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browser.test.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browser.test.ts
@@ -12,17 +12,21 @@ describe('HttpInterceptorWorker (browser)', () => {
     platform,
   });
 
-  it('should throw an error if trying to use a mismatched platform', async () => {
-    const mismatchedPlatform: HttpInterceptorWorkerPlatform = 'node';
-    expect(mismatchedPlatform).not.toBe(platform);
+  it(
+    'should throw an error if trying to use a mismatched platform',
+    async () => {
+      const mismatchedPlatform: HttpInterceptorWorkerPlatform = 'node';
+      expect(mismatchedPlatform).not.toBe(platform);
 
-    const interceptorWorker = createHttpInterceptorWorker({
-      platform: mismatchedPlatform,
-    });
-    expect(interceptorWorker.platform()).toBe(mismatchedPlatform);
+      const interceptorWorker = createHttpInterceptorWorker({
+        platform: mismatchedPlatform,
+      });
+      expect(interceptorWorker.platform()).toBe(mismatchedPlatform);
 
-    await expect(async () => {
-      await interceptorWorker.start();
-    }).rejects.toThrowError(new MismatchedHttpInterceptorWorkerPlatform(mismatchedPlatform));
-  });
+      await expect(async () => {
+        await interceptorWorker.start();
+      }).rejects.toThrowError(new MismatchedHttpInterceptorWorkerPlatform(mismatchedPlatform));
+    },
+    { timeout: 10000 },
+  );
 });

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browserNoWorker.test.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browserNoWorker.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import UnregisteredServiceWorkerError from '../errors/UnregisteredServiceWorkerError';
-import InternalHttpInterceptorWorker from '../InternalHttpInterceptorWorker';
+import { createHttpInterceptorWorker } from '../factory';
+import HttpInterceptorWorker from '../HttpInterceptorWorker';
 import { HttpInterceptorWorkerPlatform } from '../types/options';
 import { BrowserHttpWorker } from '../types/requests';
 
@@ -9,14 +10,14 @@ describe('HttpInterceptorWorker (browser, no worker)', () => {
   const platform = 'browser' satisfies HttpInterceptorWorkerPlatform;
 
   it('should throw an error after failing to start without a registered service worker', async () => {
-    const interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+    const interceptorWorker = createHttpInterceptorWorker({ platform });
 
     const interceptorStartPromise = interceptorWorker.start();
     await expect(interceptorStartPromise).rejects.toThrowError(new UnregisteredServiceWorkerError());
   });
 
   it('should throw an error after failing to start due to a unknown error', async () => {
-    const interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+    const interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
 
     const internalBrowserWorker = (await interceptorWorker.internalWorkerOrLoad()) as BrowserHttpWorker;
     const unknownError = new Error('Unknown error');

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.node.test.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.node.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import MismatchedHttpInterceptorWorkerPlatform from '../errors/MismatchedHttpInterceptorWorkerPlatform';
-import InternalHttpInterceptorWorker from '../InternalHttpInterceptorWorker';
+import { createHttpInterceptorWorker } from '../factory';
 import { HttpInterceptorWorkerPlatform } from '../types/options';
 import { declareSharedHttpInterceptorWorkerTests } from './shared/workerTests';
 
@@ -16,7 +16,7 @@ describe('HttpInterceptorWorker (Node.js)', () => {
     const mismatchedPlatform: HttpInterceptorWorkerPlatform = 'browser';
     expect(mismatchedPlatform).not.toBe(platform);
 
-    const interceptorWorker = new InternalHttpInterceptorWorker({
+    const interceptorWorker = createHttpInterceptorWorker({
       platform: mismatchedPlatform,
     });
     expect(interceptorWorker.platform()).toBe(mismatchedPlatform);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/workerTests.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/workerTests.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createHttpInterceptor } from '@/interceptor/http/interceptor/factory';
-import InternalHttpInterceptor from '@/interceptor/http/interceptor/InternalHttpInterceptor';
 import { fetchWithTimeout } from '@/utils/fetch';
 import { waitForDelay } from '@/utils/time';
 
@@ -9,7 +8,8 @@ import { HTTP_INTERCEPTOR_METHODS, HttpInterceptorSchema } from '../../../interc
 import InvalidHttpInterceptorWorkerPlatform from '../../errors/InvalidHttpInterceptorWorkerPlatform';
 import NotStartedHttpInterceptorWorkerError from '../../errors/NotStartedHttpInterceptorWorkerError';
 import OtherHttpInterceptorWorkerRunningError from '../../errors/OtherHttpInterceptorWorkerRunningError';
-import InternalHttpInterceptorWorker from '../../InternalHttpInterceptorWorker';
+import { createHttpInterceptorWorker } from '../../factory';
+import HttpInterceptorWorker from '../../HttpInterceptorWorker';
 import { HttpInterceptorWorkerPlatform } from '../../types/options';
 import { HttpRequestHandler } from '../../types/requests';
 
@@ -19,7 +19,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
   describe('Shared', () => {
     const baseURL = 'http://localhost:3000';
 
-    let interceptorWorker: InternalHttpInterceptorWorker | undefined;
+    let interceptorWorker: HttpInterceptorWorker | undefined;
 
     const responseStatus = 200;
     const responseBody = { success: true };
@@ -31,11 +31,11 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
 
     const spiedRequestHandler = vi.fn(requestHandler);
 
-    function createDefaultHttpInterceptor(worker: InternalHttpInterceptorWorker) {
+    function createDefaultHttpInterceptor(worker: HttpInterceptorWorker) {
       return createHttpInterceptor<HttpInterceptorSchema>({
         worker,
         baseURL,
-      }) as InternalHttpInterceptor<HttpInterceptorSchema>;
+      });
     }
 
     beforeEach(() => {
@@ -48,10 +48,10 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
     });
 
     it('should initialize using the correct MSW server/worker', async () => {
-      interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+      interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
       expect(interceptorWorker.platform()).toBe(platform);
 
-      expect(interceptorWorker).toBeInstanceOf(InternalHttpInterceptorWorker);
+      expect(interceptorWorker).toBeInstanceOf(HttpInterceptorWorker);
 
       await interceptorWorker.start();
 
@@ -64,12 +64,12 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       const invalidPlatform: HttpInterceptorWorkerPlatform = 'invalid';
 
       expect(() => {
-        new InternalHttpInterceptorWorker({ platform: invalidPlatform });
+        createHttpInterceptorWorker({ platform: invalidPlatform });
       }).toThrowError(InvalidHttpInterceptorWorkerPlatform);
     });
 
     it('should not throw an error when started multiple times', async () => {
-      interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+      interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
       expect(interceptorWorker.isRunning()).toBe(false);
       await interceptorWorker.start();
       expect(interceptorWorker.isRunning()).toBe(true);
@@ -80,7 +80,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
     });
 
     it('should not throw an error when stopped without running', async () => {
-      interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+      interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
       expect(interceptorWorker.isRunning()).toBe(false);
       await interceptorWorker.stop();
       expect(interceptorWorker.isRunning()).toBe(false);
@@ -91,7 +91,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
     });
 
     it('should not throw an error when stopped multiple times while running', async () => {
-      interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+      interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
       expect(interceptorWorker.isRunning()).toBe(false);
       await interceptorWorker.start();
       expect(interceptorWorker.isRunning()).toBe(true);
@@ -104,10 +104,10 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
     });
 
     it('should throw an error if multiple workers are started at the same time', async () => {
-      interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+      interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
       expect(interceptorWorker.isRunning()).toBe(false);
 
-      const otherInterceptorWorker = new InternalHttpInterceptorWorker({ platform });
+      const otherInterceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
       expect(otherInterceptorWorker.isRunning()).toBe(false);
 
       await interceptorWorker.start();
@@ -132,7 +132,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
 
     describe.each(HTTP_INTERCEPTOR_METHODS)('Method: %s', (method) => {
       it(`should intercept ${method} requests after started`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -158,7 +158,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should intercept ${method} requests after started, considering dynamic routes with a generic match`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -183,7 +183,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should intercept ${method} requests after started, considering dynamic routes with a specific match`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -214,7 +214,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should not intercept bypassed ${method} requests`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -237,7 +237,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should support intercepting ${method} requests with a delay`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -267,7 +267,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should not intercept ${method} requests before started`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
         expect(() => {
@@ -283,7 +283,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should not intercept ${method} requests after stopped`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -298,7 +298,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should clear all ${method} handlers after stopped`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -314,7 +314,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should not intercept ${method} requests having no handler after cleared`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
@@ -348,7 +348,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should not intercept ${method} requests handled by a cleared interceptor`, async () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
         const okSpiedRequestHandler = vi.fn(spiedRequestHandler).mockImplementation(() => {
@@ -430,7 +430,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
       });
 
       it(`should thrown an error if trying to apply a ${method} handler before started`, () => {
-        interceptorWorker = new InternalHttpInterceptorWorker({ platform });
+        interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
 
         const interceptor = createDefaultHttpInterceptor(interceptorWorker);
         expect(() => {

--- a/packages/zimic/src/interceptor/http/interceptorWorker/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/factory.ts
@@ -1,6 +1,6 @@
-import InternalHttpInterceptorWorker from './InternalHttpInterceptorWorker';
+import HttpInterceptorWorker from './HttpInterceptorWorker';
 import { HttpInterceptorWorkerOptions } from './types/options';
-import { HttpInterceptorWorker } from './types/public';
+import { HttpInterceptorWorker as PublicHttpInterceptorWorker } from './types/public';
 
 /**
  * Creates an HTTP interceptor worker.
@@ -9,6 +9,6 @@ import { HttpInterceptorWorker } from './types/public';
  * @returns {HttpInterceptorWorker} The created HTTP interceptor worker.
  * @see {@link https://github.com/diego-aquino/zimic#createhttpinterceptorworker}
  */
-export function createHttpInterceptorWorker(options: HttpInterceptorWorkerOptions): HttpInterceptorWorker {
-  return new InternalHttpInterceptorWorker(options);
+export function createHttpInterceptorWorker(options: HttpInterceptorWorkerOptions): PublicHttpInterceptorWorker {
+  return new HttpInterceptorWorker(options);
 }

--- a/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
@@ -1,6 +1,6 @@
 import { Default } from '@/types/utils';
 
-import InternalHttpInterceptor from '../interceptor/InternalHttpInterceptor';
+import HttpInterceptor from '../interceptor/HttpInterceptor';
 import {
   HttpInterceptorResponseSchemaStatusCode,
   HttpInterceptorSchema,
@@ -8,7 +8,7 @@ import {
   HttpInterceptorSchemaPath,
 } from '../interceptor/types/schema';
 import NoResponseDefinitionError from './errors/NoResponseDefinitionError';
-import { HttpRequestTracker } from './types/public';
+import { HttpRequestTracker as PublicHttpRequestTracker } from './types/public';
 import {
   HttpInterceptorRequest,
   HttpInterceptorResponse,
@@ -17,14 +17,14 @@ import {
   TrackedHttpInterceptorRequest,
 } from './types/requests';
 
-class InternalHttpRequestTracker<
+class HttpRequestTracker<
   Schema extends HttpInterceptorSchema,
   Method extends HttpInterceptorSchemaMethod<Schema>,
   Path extends HttpInterceptorSchemaPath<Schema, Method>,
   StatusCode extends HttpInterceptorResponseSchemaStatusCode<
     Default<Default<Schema[Path][Method]>['response']>
   > = never,
-> implements HttpRequestTracker<Schema, Method, Path, StatusCode>
+> implements PublicHttpRequestTracker<Schema, Method, Path, StatusCode>
 {
   private interceptedRequests: TrackedHttpInterceptorRequest<Default<Schema[Path][Method]>, StatusCode>[] = [];
 
@@ -34,7 +34,7 @@ class InternalHttpRequestTracker<
   >;
 
   constructor(
-    private interceptor: InternalHttpInterceptor<Schema>,
+    private interceptor: HttpInterceptor<Schema>,
     private _method: Method,
     private _path: Path,
   ) {}
@@ -53,8 +53,8 @@ class InternalHttpRequestTracker<
     declaration:
       | HttpRequestTrackerResponseDeclaration<Default<Schema[Path][Method]>, NewStatusCode>
       | HttpRequestTrackerResponseDeclarationFactory<Default<Schema[Path][Method]>, NewStatusCode>,
-  ): InternalHttpRequestTracker<Schema, Method, Path, NewStatusCode> {
-    const newThis = this as unknown as InternalHttpRequestTracker<Schema, Method, Path, NewStatusCode>;
+  ): HttpRequestTracker<Schema, Method, Path, NewStatusCode> {
+    const newThis = this as unknown as HttpRequestTracker<Schema, Method, Path, NewStatusCode>;
 
     newThis.createResponseDeclaration = this.isResponseDeclarationFactory<NewStatusCode>(declaration)
       ? declaration
@@ -77,7 +77,7 @@ class InternalHttpRequestTracker<
     return typeof declaration === 'function';
   }
 
-  bypass(): InternalHttpRequestTracker<Schema, Method, Path, StatusCode> {
+  bypass(): HttpRequestTracker<Schema, Method, Path, StatusCode> {
     this.createResponseDeclaration = undefined;
     this.interceptedRequests = [];
     return this;
@@ -124,4 +124,4 @@ class InternalHttpRequestTracker<
   }
 }
 
-export default InternalHttpRequestTracker;
+export default HttpRequestTracker;

--- a/packages/zimic/src/interceptor/http/requestTracker/__tests__/shared/requestTrackerTests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/__tests__/shared/requestTrackerTests.ts
@@ -1,15 +1,15 @@
 import { expectTypeOf, expect, vi, it, beforeAll, afterAll, describe } from 'vitest';
 
 import { createHttpInterceptor } from '@/interceptor/http/interceptor/factory';
-import InternalHttpInterceptor from '@/interceptor/http/interceptor/InternalHttpInterceptor';
+import HttpInterceptor from '@/interceptor/http/interceptor/HttpInterceptor';
 import { HttpInterceptorSchema } from '@/interceptor/http/interceptor/types/schema';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
-import InternalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/InternalHttpInterceptorWorker';
+import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import { HttpInterceptorWorkerPlatform } from '@/interceptor/http/interceptorWorker/types/options';
 import { HttpRequest, HttpResponse } from '@/interceptor/http/interceptorWorker/types/requests';
 
 import NoResponseDefinitionError from '../../errors/NoResponseDefinitionError';
-import InternalHttpRequestTracker from '../../InternalHttpRequestTracker';
+import HttpRequestTracker from '../../HttpRequestTracker';
 import {
   HttpInterceptorRequest,
   HttpRequestTrackerResponseDeclaration,
@@ -41,7 +41,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     }>;
 
     const worker = createHttpInterceptorWorker({ platform });
-    const interceptor = createHttpInterceptor<Schema>({ worker, baseURL }) as InternalHttpInterceptor<Schema>;
+    const interceptor = createHttpInterceptor<Schema>({ worker, baseURL }) as HttpInterceptor<Schema>;
 
     beforeAll(async () => {
       await worker.start();
@@ -52,7 +52,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should provide access to the method and path', () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
 
       expectTypeOf<typeof tracker.method>().toEqualTypeOf<() => 'GET'>();
       expect(tracker.method()).toBe('GET');
@@ -62,29 +62,29 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should not match any request if contains no declared response', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
       expect(tracker.matchesRequest(parsedRequest)).toBe(false);
     });
 
     it('should match any request if contains declared response', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
         status: 200,
         body: { success: true },
       });
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
       expect(tracker.matchesRequest(parsedRequest)).toBe(true);
     });
 
     it('should not match any request if bypassed', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
       expect(tracker.matchesRequest(parsedRequest)).toBe(false);
 
       tracker.bypass();
@@ -104,13 +104,13 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
       const responseStatus = 200;
       const responseBody = { success: true } as const;
 
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
         status: responseStatus,
         body: responseBody,
       });
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
       const response = await tracker.applyResponseDeclaration(parsedRequest);
 
       expect(response.status).toBe(responseStatus);
@@ -129,11 +129,11 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
         body: responseBody,
       }));
 
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
       tracker.respond(responseFactory);
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
       const response = await tracker.applyResponseDeclaration(parsedRequest);
 
       expect(response.status).toBe(responseStatus);
@@ -144,10 +144,10 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should throw an error if trying to create a response without a declared response', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
       await expect(async () => {
         await tracker.applyResponseDeclaration(parsedRequest);
@@ -155,21 +155,19 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should keep track of the intercepted requests and responses', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
         status: 200,
         body: { success: true },
       });
 
       const firstRequest = new Request(baseURL);
-      const parsedFirstRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(firstRequest);
+      const parsedFirstRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(firstRequest);
 
       const firstResponseDeclaration = await tracker.applyResponseDeclaration(parsedFirstRequest);
       const firstResponse = Response.json(firstResponseDeclaration.body, {
         status: firstResponseDeclaration.status,
       });
-      const parsedFirstResponse = await InternalHttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(
-        firstResponse,
-      );
+      const parsedFirstResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(firstResponse);
 
       tracker.registerInterceptedRequest(parsedFirstRequest, parsedFirstResponse);
 
@@ -180,15 +178,13 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
       expect(interceptedRequests[0].response).toEqual(firstResponse);
 
       const secondRequest = new Request(`${baseURL}/path`);
-      const parsedSecondRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(secondRequest);
+      const parsedSecondRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(secondRequest);
       const secondResponseDeclaration = await tracker.applyResponseDeclaration(parsedSecondRequest);
 
       const secondResponse = Response.json(secondResponseDeclaration.body, {
         status: secondResponseDeclaration.status,
       });
-      const parsedSecondResponse = await InternalHttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(
-        secondResponse,
-      );
+      const parsedSecondResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(secondResponse);
 
       tracker.registerInterceptedRequest(parsedSecondRequest, parsedSecondResponse);
 
@@ -202,7 +198,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should provide access to the raw intercepted requests and responses', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
         status: 200,
         body: { success: true },
       });
@@ -211,11 +207,11 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
         method: 'POST',
         body: JSON.stringify({ success: undefined } satisfies MethodSchema['request']['body']),
       });
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
       const responseDeclaration = await tracker.applyResponseDeclaration(parsedRequest);
       const response = Response.json(responseDeclaration.body, { status: responseDeclaration.status });
-      const parsedResponse = await InternalHttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
+      const parsedResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
 
       tracker.registerInterceptedRequest(parsedRequest, parsedResponse);
 
@@ -245,17 +241,17 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should provide no access to hidden properties in raw intercepted requests and responses', async () => {
-      const tracker = new InternalHttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
         status: 200,
         body: { success: true },
       });
 
       const request = new Request(baseURL);
-      const parsedRequest = await InternalHttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+      const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
       const responseDeclaration = await tracker.applyResponseDeclaration(parsedRequest);
       const response = Response.json(responseDeclaration.body, { status: responseDeclaration.status });
-      const parsedResponse = await InternalHttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
+      const parsedResponse = await HttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
 
       tracker.registerInterceptedRequest(parsedRequest, parsedResponse);
 

--- a/packages/zimic/turbo.json
+++ b/packages/zimic/turbo.json
@@ -14,7 +14,7 @@
 
     "test:turbo": {
       "dependsOn": ["^build", "deps:init-msw"],
-      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts", ".swcrc", "jest.config.js"]
+      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "tsup.config.ts"]
     },
 
     "lint:turbo": {


### PR DESCRIPTION
### Refactor
- [#zimic] Improve internal class names
  - `InternalHttpInterceptor` -> `HttpInterceptor`
  - `InternalHttpInterceptorWorker` -> `HttpInterceptorWorker`
  - `InternalHttpRequestTracker` -> `HttpRequestTracker`

### Chore
- [zimic-test-client, #release, #zimic] Removed unused file references
