### PR TITLE
fix: ignore example postinstall errors

### DIFF
--- a/examples/with-vitest-browser/package.json
+++ b/examples/with-vitest-browser/package.json
@@ -8,7 +8,7 @@
     "types:check": "tsc --noEmit",
     "deps:install-playwright": "pnpm playwright install chromium",
     "deps:init-zimic": "zimic browser init ./public",
-    "postinstall": "pnpm deps:install-playwright && pnpm deps:init-zimic"
+    "postinstall": "pnpm deps:install-playwright && pnpm deps:init-zimic || echo 'Could not postinstall.'"
   },
   "dependencies": {
     "zimic": "latest"


### PR DESCRIPTION
### Fixes
- [examples-vitest-browser] Ignored postinstall errors, preventing build problems on GitHub Actions.
