### PR TITLE
fix: enable jest vm modules in examples

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -71,9 +71,12 @@ jobs:
             's/link-workspace-packages = true/link-workspace-packages = false/' \
             .npmrc
 
-          sed -E -i \
-            's/"zimic([0-9]?)": ".*"/"zimic\1": "npm:zimic@${{ steps.npm-tag.outputs.tag }}"/' \
-            package.json **/package.json
+          for packageJSON in apps/zimic-test-client/package.json examples/package.json examples/*/package.json; do
+            sed -E -i \
+              's/"zimic([0-9]?)": ".*"/"zimic\1": "npm:zimic@${{ steps.npm-tag.outputs.tag }}"/' \
+              $packageJSON
+          done
+
 
           pnpm install --no-frozen-lockfile
 

--- a/examples/with-jest-jsdom/README.md
+++ b/examples/with-jest-jsdom/README.md
@@ -30,10 +30,17 @@ where the repository is found and another where it is not.
 #### Configuration
 
 - Jest configuration: [`jest.config.js`](./jest.config.js)
+
+  > The flag `--experimental-vm-modules`, present in the command `test` in the [`package.json`](./package.json), is
+  > required by Jest because Zimic uses dynamic imports internally.
+
 - Test environment: [`tests/environment.ts`](./tests/environment.ts)
+
   > This custom environment is necessary to expose the Global Fetch API resources, such as `fetch`, to the test context.
   > [JSDOM currently does not expose them](https://github.com/jsdom/jsdom/issues/1724).
+
 - Test resolver: [`tests/resolver.js`](./tests/resolver.js)
+
   > JSDOM runs on Node.js, but uses browser imports when present. Therefore, this resolver is necessary to remove the
   > [browser condition of MSW-related imports](https://github.com/mswjs/msw/issues/1786) to prevent test runtime
   > errors."

--- a/examples/with-jest-jsdom/package.json
+++ b/examples/with-jest-jsdom/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "scripts": {
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:turbo": "pnpm run test",
     "types:check": "tsc --noEmit"
   },

--- a/examples/with-jest-node/README.md
+++ b/examples/with-jest-node/README.md
@@ -31,3 +31,6 @@ where the repository is found and another where it is not.
 #### Configuration
 
 - Jest configuration: [`jest.config.js`](./jest.config.js)
+
+  > The flag `--experimental-vm-modules`, present in the command `test` in the [`package.json`](./package.json), is
+  > required by Jest because Zimic uses dynamic imports internally.

--- a/examples/with-jest-node/package.json
+++ b/examples/with-jest-node/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "scripts": {
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:turbo": "pnpm run test",
     "types:check": "tsc --noEmit"
   },

--- a/examples/with-vitest-browser/README.md
+++ b/examples/with-vitest-browser/README.md
@@ -30,7 +30,9 @@ where the repository is found and another where it is not.
 ### Test
 
 - Test suite: [`tests/example.test.ts`](./tests/example.test.ts)
+
 - Test setup file: [`tests/browserSetup.ts`](./tests/browserSetup.ts)
+
   > IMPORTANT: As a workaround, this setup file must be imported in each test file. Currently, Browser Mode is
   > experimental and Vitest runs the setup file in a different process than the test files, so the worker started on
   > [`tests/browserSetup.ts`](./tests/browserSetup.ts) is not shared between them.


### PR DESCRIPTION
### Fixes
- [examples] Enabled vm modules in Jest examples, required because Zimic uses dynamic imports.
- [ci] Restricted remote Zimic versions to zimic-test-client and examples.
