### PR TITLE
docs: rename `route` terms to `path`

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -120,7 +120,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
     });
   });
 
-  it('should support intercepting DELETE requests with a dynamic route', async () => {
+  it('should support intercepting DELETE requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         DELETE: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -114,7 +114,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
     });
   });
 
-  it('should support intercepting GET requests with a dynamic route', async () => {
+  it('should support intercepting GET requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         GET: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -98,7 +98,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
     });
   });
 
-  it('should support intercepting HEAD requests with a dynamic route', async () => {
+  it('should support intercepting HEAD requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         HEAD: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -112,7 +112,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
     });
   });
 
-  it('should support intercepting OPTIONS requests with a dynamic route', async () => {
+  it('should support intercepting OPTIONS requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/filters/:id': {
         OPTIONS: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -121,7 +121,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     });
   });
 
-  it('should support intercepting PATCH requests with a dynamic route', async () => {
+  it('should support intercepting PATCH requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         PATCH: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -121,7 +121,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
     });
   });
 
-  it('should support intercepting POST requests with a dynamic route', async () => {
+  it('should support intercepting POST requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         POST: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -121,7 +121,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     });
   });
 
-  it('should support intercepting PUT requests with a dynamic route', async () => {
+  it('should support intercepting PUT requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         PUT: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -50,7 +50,7 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
     expectTypeOf<RequestBody>().toEqualTypeOf<User>();
   });
 
-  it('should correctly type requests with dynamic routes', () => {
+  it('should correctly type requests with dynamic paths', () => {
     const interceptor = createHttpInterceptor<{
       '/groups/:id/users': {
         POST: {
@@ -75,7 +75,7 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
     type GenericRequestBody = (typeof genericCreationRequests)[number]['body'];
     expectTypeOf<GenericRequestBody>().toEqualTypeOf<User>();
 
-    // @ts-expect-error The literal path is required when using route param interpolation
+    // @ts-expect-error The literal path is required when using path param interpolation
     interceptor.post(`/groups/${1}/users`);
 
     const specificCreationTracker = interceptor.post<'/groups/:id/users'>(`/groups/${1}/users`).respond((request) => {
@@ -123,7 +123,7 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
     expectTypeOf<FailedResponseBody>().toEqualTypeOf<{ message: string }>();
   });
 
-  it('should correctly type responses with dynamic routes, based on the applied status code', () => {
+  it('should correctly type responses with dynamic paths, based on the applied status code', () => {
     const interceptor = createHttpInterceptor<{
       '/groups/:id/users': {
         GET: {
@@ -305,7 +305,7 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
     interceptor.put('/users');
   });
 
-  it('should correctly type routes with multiple methods', () => {
+  it('should correctly type paths with multiple methods', () => {
     type Schema = HttpInterceptorSchema.Root<{
       '/users': {
         POST: {

--- a/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
@@ -1,6 +1,6 @@
 import { HttpRequestTracker } from '../../requestTracker/types/public';
 import {
-  AllowAnyStringInRouteParameters,
+  AllowAnyStringInPathParameters,
   HttpInterceptorMethod,
   HttpInterceptorSchema,
   HttpInterceptorSchemaMethod,
@@ -17,7 +17,7 @@ export interface EffectiveHttpInterceptorMethodHandler<
     Path extends LiteralHttpInterceptorSchemaPath<Schema, Method> | void = void,
     ActualPath extends Exclude<Path, void> = Exclude<Path, void>,
   >(
-    path: AllowAnyStringInRouteParameters<ActualPath>,
+    path: AllowAnyStringInPathParameters<ActualPath>,
   ): HttpRequestTracker<Schema, Method, ActualPath>;
 }
 

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -7,6 +7,6 @@ export interface HttpInterceptorOptions {
    */
   worker: HttpInterceptorWorker;
 
-  /** The base URL used by the interceptor. This URL will be prepended to any routes used by the interceptor. */
+  /** The base URL used by the interceptor. This URL will be prepended to any paths used by the interceptor. */
   baseURL: string;
 }

--- a/packages/zimic/src/interceptor/http/interceptor/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/public.ts
@@ -22,7 +22,7 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns A GET {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
    *   path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original
    *
    *   Path as a type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
@@ -33,8 +33,8 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns A POST {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
    *   path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   *   as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+   *   type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   post: HttpInterceptorMethodHandler<Schema, 'POST'>;
@@ -43,8 +43,8 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns A PATCH {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
    *   provided path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   *   as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+   *   type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   patch: HttpInterceptorMethodHandler<Schema, 'PATCH'>;
@@ -53,8 +53,8 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns A PUT {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
    *   path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   *   as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+   *   type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   put: HttpInterceptorMethodHandler<Schema, 'PUT'>;
@@ -63,8 +63,8 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns A DELETE {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
    *   provided path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   *   as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+   *   type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   delete: HttpInterceptorMethodHandler<Schema, 'DELETE'>;
@@ -73,8 +73,8 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns A HEAD {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the provided
    *   path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   *   as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+   *   type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   head: HttpInterceptorMethodHandler<Schema, 'HEAD'>;
@@ -83,8 +83,8 @@ export interface HttpInterceptor<Schema extends HttpInterceptorSchema> {
    * @returns An OPTIONS {@link https://github.com/diego-aquino/zimic#httprequesttracker HttpRequestTracker} for the
    *   provided path. The path and method must be declared in the interceptor schema.
    *
-   *   Paths with dynamic route parameters, such as `/users/:id`, are supported, but you need to specify the original path
-   *   as a type parameter to get type-inference and type-validation.
+   *   Paths with dynamic parameters, such as `/users/:id`, are supported, but you need to specify the original path as a
+   *   type parameter to get type-inference and type-validation.
    * @see {@link https://github.com/diego-aquino/zimic#interceptormethodpath}
    */
   options: HttpInterceptorMethodHandler<Schema, 'OPTIONS'>;

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -65,9 +65,9 @@ export type LooseLiteralHttpInterceptorSchemaPath<
   [Path in Extract<keyof Schema, string>]: Method extends keyof Schema[Path] ? Path : never;
 }[Extract<keyof Schema, string>];
 
-export type AllowAnyStringInRouteParameters<Path extends string> =
+export type AllowAnyStringInPathParameters<Path extends string> =
   Path extends `${infer Prefix}:${string}/${infer Suffix}`
-    ? `${Prefix}${string}/${AllowAnyStringInRouteParameters<Suffix>}`
+    ? `${Prefix}${string}/${AllowAnyStringInPathParameters<Suffix>}`
     : Path extends `${infer Prefix}:${string}`
       ? `${Prefix}${string}`
       : Path;
@@ -75,7 +75,7 @@ export type AllowAnyStringInRouteParameters<Path extends string> =
 export type NonLiteralHttpInterceptorSchemaPath<
   Schema extends HttpInterceptorSchema,
   Method extends HttpInterceptorSchemaMethod<Schema>,
-> = AllowAnyStringInRouteParameters<LiteralHttpInterceptorSchemaPath<Schema, Method>>;
+> = AllowAnyStringInPathParameters<LiteralHttpInterceptorSchemaPath<Schema, Method>>;
 
 export type HttpInterceptorSchemaPath<
   Schema extends HttpInterceptorSchema,

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/workerTests.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/workerTests.ts
@@ -157,7 +157,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
         expect(body).toEqual(responseBody);
       });
 
-      it(`should intercept ${method} requests after started, considering dynamic routes with a generic match`, async () => {
+      it(`should intercept ${method} requests after started, considering dynamic paths with a generic match`, async () => {
         interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 
@@ -182,7 +182,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
         expect(body).toEqual(responseBody);
       });
 
-      it(`should intercept ${method} requests after started, considering dynamic routes with a specific match`, async () => {
+      it(`should intercept ${method} requests after started, considering dynamic paths with a specific match`, async () => {
         interceptorWorker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
         await interceptorWorker.start();
 

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -17,7 +17,7 @@ import {
  * the intercepted requests and their responses, allowing checks about how many requests your application made and with
  * which parameters.
  *
- * When multiple trackers of the same interceptor match the same method and route, the _last_ tracker created with
+ * When multiple trackers of the same interceptor match the same method and path, the _last_ tracker created with
  * {@link https://github.com/diego-aquino/zimic#interceptormethodpath `interceptor.<method>(path)`} will be used.
  *
  * @see {@link https://github.com/diego-aquino/zimic#httprequesttracker}


### PR DESCRIPTION
### Documentation
- [#zimic] Renamed `route` terms to `path`, to keep consistency with the current types, methods, parameters and documentation.
