### PR TITLE
refactor(#zimic): `@ts-expect-error` descriptions

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptor.ts
@@ -19,14 +19,14 @@ import {
 } from './types/schema';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyInternalHttpRequestTracker = HttpRequestTracker<any, any, any, any>;
+type AnyHttpRequestTracker = HttpRequestTracker<any, any, any, any>;
 
 class HttpInterceptor<Schema extends HttpInterceptorSchema> implements PublicHttpInterceptor<Schema> {
   private _baseURL: string;
   protected worker: HttpInterceptorWorker;
 
   private trackersByMethod: {
-    [Method in HttpInterceptorMethod]: Map<string, AnyInternalHttpRequestTracker[]>;
+    [Method in HttpInterceptorMethod]: Map<string, AnyHttpRequestTracker[]>;
   } = {
     GET: new Map(),
     POST: new Map(),

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -189,12 +189,12 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
     });
 
     interceptor.get('/users').respond({
-      // @ts-expect-error
+      // @ts-expect-error The status code should match the schema
       status: 201,
       body: users,
     });
 
-    // @ts-expect-error
+    // @ts-expect-error The status code should match the schema
     interceptor.get('/users').respond(() => ({
       status: 201,
       body: users,
@@ -236,10 +236,10 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
 
     interceptor.get('/users').respond({
       status: 200,
-      // @ts-expect-error
+      // @ts-expect-error The response body should match the schema
       body: '',
     });
-    // @ts-expect-error
+    // @ts-expect-error The response body should match the schema
     interceptor.get('/users').respond(() => ({
       status: 200,
       body: '',
@@ -247,10 +247,10 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
 
     interceptor.post('/notifications/read').respond({
       status: 204,
-      // @ts-expect-error
+      // @ts-expect-error The response body should match the schema
       body: users,
     });
-    // @ts-expect-error
+    // @ts-expect-error The response body should match the schema
     interceptor.post('/notifications/read').respond(() => ({
       status: 204,
       body: users,
@@ -287,21 +287,21 @@ export function declareTypeHttpInterceptorTests({ platform }: SharedHttpIntercep
     interceptor.get<'/users/:id'>(`/users/${123}`);
     interceptor.post('/notifications/read');
 
-    // @ts-expect-error
+    // @ts-expect-error The path `/users` does not contain a POST method
     interceptor.post('/users');
-    // @ts-expect-error
+    // @ts-expect-error The path `/users/:id` does not contain a POST method
     interceptor.post('/users/:id');
-    // @ts-expect-error
+    // @ts-expect-error The path `/users/:id` with dynamic parameter does not contain a POST method
     interceptor.post(`/users/${123}`);
-    // @ts-expect-error
+    // @ts-expect-error The path `/notifications/read` does not contain a GET method
     interceptor.get('/notifications/read');
 
-    // @ts-expect-error
+    // @ts-expect-error The path `/path` is not declared
     interceptor.get('/path');
-    // @ts-expect-error
+    // @ts-expect-error The path `/path` is not declared
     interceptor.post('/path');
 
-    // @ts-expect-error
+    // @ts-expect-error The path `/users` does not contain a PUT method
     interceptor.put('/users');
   });
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/workerTests.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/workerTests.ts
@@ -60,7 +60,7 @@ export function declareSharedHttpInterceptorWorkerTests(options: { platform: Htt
     });
 
     it('should thrown an error if an invalid platform is provided', () => {
-      // @ts-expect-error
+      // @ts-expect-error Forcing an invalid platform
       const invalidPlatform: HttpInterceptorWorkerPlatform = 'invalid';
 
       expect(() => {

--- a/packages/zimic/src/interceptor/http/requestTracker/__tests__/InternalHttpRequestTracker.browser.test.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/__tests__/InternalHttpRequestTracker.browser.test.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest';
 
 import { declareSharedHttpRequestTrackerTests } from './shared/requestTrackerTests';
 
-describe('InternalHttpRequestTracker (browser)', () => {
+describe('HttpRequestTracker (browser)', () => {
   declareSharedHttpRequestTrackerTests({
     platform: 'browser',
   });

--- a/packages/zimic/src/interceptor/http/requestTracker/__tests__/InternalHttpRequestTracker.node.test.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/__tests__/InternalHttpRequestTracker.node.test.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest';
 
 import { declareSharedHttpRequestTrackerTests } from './shared/requestTrackerTests';
 
-describe('InternalHttpRequestTracker (Node.js)', () => {
+describe('HttpRequestTracker (Node.js)', () => {
   declareSharedHttpRequestTrackerTests({
     platform: 'node',
   });


### PR DESCRIPTION
### Refactoring
- [#zimic] Renamed request tracker tests to match their class names.

### Documentation
- [#zimic] Added comments to expected TypeScript errors for clarity.
