### PR TITLE
feat(#zimic): search params support (#84)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -30,6 +30,10 @@ import {
   type TrackedHttpInterceptorRequest,
   type HttpInterceptorWorkerPlatform,
   type HttpInterceptorWorkerOptions,
+  type HttpSearchParamsSchema,
+  type HttpSearchParamsSchemaTuple,
+  type HttpInterceptorSearchParamsSchema,
+  type HttpInterceptorBodySchema,
 } from 'zimic0/interceptor';
 
 describe('Exports', () => {
@@ -56,9 +60,14 @@ describe('Exports', () => {
     expectTypeOf<TrackedHttpInterceptorRequest<never>>().not.toBeAny();
     expectTypeOf<HttpRequestTracker<never, never, never>>().not.toBeAny();
 
+    expectTypeOf<HttpSearchParamsSchema>().not.toBeAny();
+    expectTypeOf<HttpSearchParamsSchemaTuple<never>>().not.toBeAny();
+
     expectTypeOf<HttpInterceptorOptions>().not.toBeAny();
     expectTypeOf<HttpInterceptorMethod>().not.toBeAny();
     expectTypeOf<HttpInterceptorRequestSchema>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSearchParamsSchema>().not.toBeAny();
+    expectTypeOf<HttpInterceptorBodySchema>().not.toBeAny();
     expectTypeOf<HttpInterceptorResponseSchema>().not.toBeAny();
     expectTypeOf<HttpInterceptorResponseSchemaByStatusCode>().not.toBeAny();
     expectTypeOf<HttpInterceptorResponseSchemaStatusCode<never>>().not.toBeAny();

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -124,7 +124,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
 
   it('should support intercepting DELETE requests having search params', async () => {
     type UserDeleteSearchParams = HttpInterceptorSchema.RequestSearchParams<{
-      from?: string;
+      tag?: string;
     }>;
 
     await usingHttpInterceptor<{
@@ -153,7 +153,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
       expect(deletionRequests).toHaveLength(0);
 
       const searchParams = new HttpSearchParams<UserDeleteSearchParams>({
-        from: 'admin',
+        tag: 'admin',
       });
 
       const deletionResponse = await fetch(`${baseURL}/users/${1}?${searchParams.toString()}`, { method: 'DELETE' });
@@ -165,7 +165,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
 
       expectTypeOf(deletionRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserDeleteSearchParams>>();
       expect(deletionRequest.searchParams).toEqual(searchParams);
-      expect(deletionRequest.searchParams.get('from')).toBe('admin');
+      expect(deletionRequest.searchParams.get('tag')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -3,8 +3,10 @@ import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import HttpSearchParams from '@/interceptor/http/searchParams/HttpSearchParams';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
+import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareHeadHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
@@ -95,6 +97,52 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
 
       expectTypeOf(headRequest.response.body).toEqualTypeOf<null>();
       expect(headRequest.response.body).toBe(null);
+    });
+  });
+
+  it('should support intercepting HEAD requests having search params', async () => {
+    type UserHeadSearchParams = HttpInterceptorSchema.RequestSearchParams<{
+      from?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        HEAD: {
+          request: {
+            searchParams: UserHeadSearchParams;
+          };
+          response: {
+            200: {};
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const headTracker = interceptor.head('/users').respond((request) => {
+        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserHeadSearchParams>>();
+
+        return {
+          status: 200,
+        };
+      });
+      expect(headTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const headRequests = headTracker.requests();
+      expect(headRequests).toHaveLength(0);
+
+      const searchParams = new HttpSearchParams<UserHeadSearchParams>({
+        from: 'admin',
+      });
+
+      const headResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'HEAD' });
+      expect(headResponse.status).toBe(200);
+
+      expect(headRequests).toHaveLength(1);
+      const [headRequest] = headRequests;
+      expect(headRequest).toBeInstanceOf(Request);
+
+      expectTypeOf(headRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserHeadSearchParams>>();
+      expect(headRequest.searchParams).toEqual(searchParams);
+      expect(headRequest.searchParams.get('from')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -102,7 +102,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
 
   it('should support intercepting HEAD requests having search params', async () => {
     type UserHeadSearchParams = HttpInterceptorSchema.RequestSearchParams<{
-      from?: string;
+      tag?: string;
     }>;
 
     await usingHttpInterceptor<{
@@ -130,7 +130,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       expect(headRequests).toHaveLength(0);
 
       const searchParams = new HttpSearchParams<UserHeadSearchParams>({
-        from: 'admin',
+        tag: 'admin',
       });
 
       const headResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'HEAD' });
@@ -142,7 +142,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
 
       expectTypeOf(headRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserHeadSearchParams>>();
       expect(headRequest.searchParams).toEqual(searchParams);
-      expect(headRequest.searchParams.get('from')).toBe('admin');
+      expect(headRequest.searchParams.get('tag')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -3,8 +3,10 @@ import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import HttpSearchParams from '@/interceptor/http/searchParams/HttpSearchParams';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
+import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
@@ -76,6 +78,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
     }>({ worker, baseURL }, async (interceptor) => {
       const optionsTracker = interceptor.options('/filters').respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<Filters>();
+
         return {
           status: 200,
         };
@@ -109,6 +112,52 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
 
       expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
       expect(optionsRequest.response.body).toBe(null);
+    });
+  });
+
+  it('should support intercepting OPTIONS requests having search params', async () => {
+    type OptionsSearchParams = HttpInterceptorSchema.RequestSearchParams<{
+      from?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/filters': {
+        OPTIONS: {
+          request: {
+            searchParams: OptionsSearchParams;
+          };
+          response: {
+            200: {};
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const optionsTracker = interceptor.options('/filters').respond((request) => {
+        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<OptionsSearchParams>>();
+
+        return {
+          status: 200,
+        };
+      });
+      expect(optionsTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const optionsRequests = optionsTracker.requests();
+      expect(optionsRequests).toHaveLength(0);
+
+      const searchParams = new HttpSearchParams<OptionsSearchParams>({
+        from: 'admin',
+      });
+
+      const optionsResponse = await fetch(`${baseURL}/filters?${searchParams.toString()}`, { method: 'OPTIONS' });
+      expect(optionsResponse.status).toBe(200);
+
+      expect(optionsRequests).toHaveLength(1);
+      const [optionsRequest] = optionsRequests;
+      expect(optionsRequest).toBeInstanceOf(Request);
+
+      expectTypeOf(optionsRequest.searchParams).toEqualTypeOf<HttpSearchParams<OptionsSearchParams>>();
+      expect(optionsRequest.searchParams).toEqual(searchParams);
+      expect(optionsRequest.searchParams.get('from')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -117,7 +117,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
 
   it('should support intercepting OPTIONS requests having search params', async () => {
     type OptionsSearchParams = HttpInterceptorSchema.RequestSearchParams<{
-      from?: string;
+      tag?: string;
     }>;
 
     await usingHttpInterceptor<{
@@ -145,7 +145,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       expect(optionsRequests).toHaveLength(0);
 
       const searchParams = new HttpSearchParams<OptionsSearchParams>({
-        from: 'admin',
+        tag: 'admin',
       });
 
       const optionsResponse = await fetch(`${baseURL}/filters?${searchParams.toString()}`, { method: 'OPTIONS' });
@@ -157,7 +157,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
 
       expectTypeOf(optionsRequest.searchParams).toEqualTypeOf<HttpSearchParams<OptionsSearchParams>>();
       expect(optionsRequest.searchParams).toEqual(searchParams);
-      expect(optionsRequest.searchParams.get('from')).toBe('admin');
+      expect(optionsRequest.searchParams.get('tag')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -3,8 +3,10 @@ import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import HttpSearchParams from '@/interceptor/http/searchParams/HttpSearchParams';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
+import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
@@ -118,6 +120,53 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual<User>({ name: userName });
+    });
+  });
+
+  it('should support intercepting PATCH requests having search params', async () => {
+    type UserUpdateSearchParams = HttpInterceptorSchema.RequestSearchParams<{
+      from?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        PATCH: {
+          request: {
+            searchParams: UserUpdateSearchParams;
+          };
+          response: {
+            200: { body: User };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const updateTracker = interceptor.patch('/users').respond((request) => {
+        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
+
+        return {
+          status: 200,
+          body: users[0],
+        };
+      });
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const updateRequests = updateTracker.requests();
+      expect(updateRequests).toHaveLength(0);
+
+      const searchParams = new HttpSearchParams<UserUpdateSearchParams>({
+        from: 'admin',
+      });
+
+      const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
+      expect(updateResponse.status).toBe(200);
+
+      expect(updateRequests).toHaveLength(1);
+      const [updateRequest] = updateRequests;
+      expect(updateRequest).toBeInstanceOf(Request);
+
+      expectTypeOf(updateRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
+      expect(updateRequest.searchParams).toEqual(searchParams);
+      expect(updateRequest.searchParams.get('from')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -125,7 +125,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   it('should support intercepting PATCH requests having search params', async () => {
     type UserUpdateSearchParams = HttpInterceptorSchema.RequestSearchParams<{
-      from?: string;
+      tag?: string;
     }>;
 
     await usingHttpInterceptor<{
@@ -154,7 +154,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       expect(updateRequests).toHaveLength(0);
 
       const searchParams = new HttpSearchParams<UserUpdateSearchParams>({
-        from: 'admin',
+        tag: 'admin',
       });
 
       const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
@@ -166,7 +166,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
       expectTypeOf(updateRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
       expect(updateRequest.searchParams).toEqual(searchParams);
-      expect(updateRequest.searchParams.get('from')).toBe('admin');
+      expect(updateRequest.searchParams.get('tag')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -125,7 +125,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
 
   it('should support intercepting POST requests having search params', async () => {
     type UserCreationSearchParams = HttpInterceptorSchema.RequestSearchParams<{
-      from?: string;
+      tag?: string;
     }>;
 
     await usingHttpInterceptor<{
@@ -154,7 +154,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
       expect(creationRequests).toHaveLength(0);
 
       const searchParams = new HttpSearchParams<UserCreationSearchParams>({
-        from: 'admin',
+        tag: 'admin',
       });
 
       const creationResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'POST' });
@@ -169,7 +169,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
 
       expectTypeOf(creationRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserCreationSearchParams>>();
       expect(creationRequest.searchParams).toEqual(searchParams);
-      expect(creationRequest.searchParams.get('from')).toBe('admin');
+      expect(creationRequest.searchParams.get('tag')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -3,8 +3,10 @@ import { afterAll, afterEach, beforeAll, expect, expectTypeOf, it } from 'vitest
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import HttpSearchParams from '@/interceptor/http/searchParams/HttpSearchParams';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
+import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declarePostHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
@@ -118,6 +120,56 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
 
       expectTypeOf(creationRequest.response.body).toEqualTypeOf<User>();
       expect(creationRequest.response.body).toEqual<User>({ name: userName });
+    });
+  });
+
+  it('should support intercepting POST requests having search params', async () => {
+    type UserCreationSearchParams = HttpInterceptorSchema.RequestSearchParams<{
+      from?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        POST: {
+          request: {
+            searchParams: UserCreationSearchParams;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const creationTracker = interceptor.post('/users').respond((request) => {
+        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserCreationSearchParams>>();
+
+        return {
+          status: 201,
+          body: users[0],
+        };
+      });
+      expect(creationTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const creationRequests = creationTracker.requests();
+      expect(creationRequests).toHaveLength(0);
+
+      const searchParams = new HttpSearchParams<UserCreationSearchParams>({
+        from: 'admin',
+      });
+
+      const creationResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'POST' });
+      expect(creationResponse.status).toBe(201);
+
+      const createdUsers = (await creationResponse.json()) as User;
+      expect(createdUsers).toEqual(users[0]);
+
+      expect(creationRequests).toHaveLength(1);
+      const [creationRequest] = creationRequests;
+      expect(creationRequest).toBeInstanceOf(Request);
+
+      expectTypeOf(creationRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserCreationSearchParams>>();
+      expect(creationRequest.searchParams).toEqual(searchParams);
+      expect(creationRequest.searchParams.get('from')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -125,7 +125,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   it('should support intercepting PUT requests having search params', async () => {
     type UserUpdateSearchParams = HttpInterceptorSchema.RequestSearchParams<{
-      from?: string;
+      tag?: string;
     }>;
 
     await usingHttpInterceptor<{
@@ -154,7 +154,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       expect(updateRequests).toHaveLength(0);
 
       const searchParams = new HttpSearchParams<UserUpdateSearchParams>({
-        from: 'admin',
+        tag: 'admin',
       });
 
       const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PUT' });
@@ -166,7 +166,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
       expectTypeOf(updateRequest.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
       expect(updateRequest.searchParams).toEqual(searchParams);
-      expect(updateRequest.searchParams.get('from')).toBe('admin');
+      expect(updateRequest.searchParams.get('tag')).toBe('admin');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -1,17 +1,23 @@
 import { Default, UnionToIntersection, Prettify, IfAny } from '@/types/utils';
 
 import { HttpRequestHandlerContext, DefaultBody } from '../../interceptorWorker/types/requests';
+import { HttpSearchParamsSchema } from '../../searchParams/HttpSearchParams';
 import { HttpInterceptor } from './public';
 
 export const HTTP_INTERCEPTOR_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const;
 export type HttpInterceptorMethod = (typeof HTTP_INTERCEPTOR_METHODS)[number];
 
+export type HttpInterceptorSearchParamsSchema = HttpSearchParamsSchema;
+
+export type HttpInterceptorBodySchema = DefaultBody;
+
 export interface HttpInterceptorRequestSchema {
-  body?: DefaultBody;
+  searchParams?: HttpInterceptorSearchParamsSchema;
+  body?: HttpInterceptorBodySchema;
 }
 
 export interface HttpInterceptorResponseSchema {
-  body?: DefaultBody;
+  body?: HttpInterceptorBodySchema;
 }
 
 export interface HttpInterceptorResponseSchemaByStatusCode {
@@ -37,10 +43,18 @@ export interface HttpInterceptorSchema {
 
 export namespace HttpInterceptorSchema {
   export type Root<Schema extends HttpInterceptorSchema> = Prettify<Schema>;
+
   export type Path<Schema extends HttpInterceptorPathSchema> = Prettify<Schema>;
+
   export type Method<Schema extends HttpInterceptorMethodSchema> = Prettify<Schema>;
+
   export type Request<Schema extends HttpInterceptorRequestSchema> = Prettify<Schema>;
+  export type RequestBody<Schema extends HttpInterceptorBodySchema> = Prettify<Schema>;
+  export type RequestSearchParams<Schema extends HttpInterceptorSearchParamsSchema> = Prettify<Schema>;
+
   export type Response<Schema extends HttpInterceptorResponseSchema> = Prettify<Schema>;
+  export type ResponseBody<Schema extends HttpInterceptorBodySchema> = Prettify<Schema>;
+
   export type ResponseByStatusCode<Schema extends HttpInterceptorResponseSchemaByStatusCode> = Prettify<Schema>;
 }
 

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -1,7 +1,7 @@
 import { Default, UnionToIntersection, Prettify, IfAny } from '@/types/utils';
 
 import { HttpRequestHandlerContext, DefaultBody } from '../../interceptorWorker/types/requests';
-import { HttpSearchParamsSchema } from '../../searchParams/HttpSearchParams';
+import { HttpSearchParamsSchema } from '../../searchParams/types';
 import { HttpInterceptor } from './public';
 
 export const HTTP_INTERCEPTOR_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -21,6 +21,7 @@ import {
   HttpInterceptorRequest,
   HttpInterceptorResponse,
 } from '../requestTracker/types/requests';
+import HttpSearchParams from '../searchParams/HttpSearchParams';
 import InvalidHttpInterceptorWorkerPlatform from './errors/InvalidHttpInterceptorWorkerPlatform';
 import MismatchedHttpInterceptorWorkerPlatform from './errors/MismatchedHttpInterceptorWorkerPlatform';
 import NotStartedHttpInterceptorWorkerError from './errors/NotStartedHttpInterceptorWorkerError';
@@ -240,8 +241,10 @@ class HttpInterceptorWorker implements PublicHttpInterceptorWorker {
     rawRequest: HttpRequest,
   ): Promise<HttpInterceptorRequest<MethodSchema>> {
     const rawRequestClone = rawRequest.clone();
-
     const parsedBody = await this.parseRawBody(rawRequest);
+
+    const parsedURL = new URL(rawRequest.url);
+    const searchParams = new HttpSearchParams(parsedURL.searchParams);
 
     const parsedRequest = new Proxy(rawRequest as unknown as HttpInterceptorRequest<MethodSchema>, {
       has(target, property: keyof HttpInterceptorRequest<MethodSchema>) {
@@ -257,6 +260,9 @@ class HttpInterceptorWorker implements PublicHttpInterceptorWorker {
         }
         if (property === 'body') {
           return parsedBody;
+        }
+        if (property === 'searchParams') {
+          return searchParams;
         }
         if (property === 'raw') {
           return rawRequestClone;

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -6,6 +6,7 @@ import {
   HttpInterceptorResponseSchemaStatusCode,
 } from '../../interceptor/types/schema';
 import { HttpRequest, HttpResponse } from '../../interceptorWorker/types/requests';
+import HttpSearchParams from '../../searchParams/HttpSearchParams';
 
 export type HttpRequestTrackerResponseAttribute<
   ResponseSchema extends HttpInterceptorResponseSchema,
@@ -30,6 +31,7 @@ export type HttpRequestTrackerResponseDeclarationFactory<
 
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body> {
+  searchParams: HttpSearchParams<Default<Default<MethodSchema['request'], { searchParams: never }>['searchParams']>>;
   body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
   raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;
 }

--- a/packages/zimic/src/interceptor/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/HttpSearchParams.ts
@@ -2,7 +2,7 @@ import { ReplaceBy, Defined, ArrayItemIfArray, NonArrayKey, ArrayKey } from '@/t
 
 import { HttpSearchParamsSchema, HttpSearchParamsSchemaTuple } from './types';
 
-function pickDefinedPrimitiveProperties<Schema extends HttpSearchParamsSchema>(searchParamsInit: Schema) {
+function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(searchParamsInit: Schema) {
   return Object.entries(searchParamsInit).reduce<Record<string, string>>((accumulated, [key, value]) => {
     if (value !== undefined && !Array.isArray(value)) {
       accumulated[key] = value;
@@ -18,7 +18,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends UR
     if (init instanceof URLSearchParams || Array.isArray(init) || typeof init === 'string' || !init) {
       super(init);
     } else {
-      super(pickDefinedPrimitiveProperties(init));
+      super(pickPrimitiveProperties(init));
       this.populateInitArrayProperties(init);
     }
   }

--- a/packages/zimic/src/interceptor/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/HttpSearchParams.ts
@@ -1,6 +1,8 @@
 import { ReplaceBy, Defined, ArrayItemIfArray, NonArrayKey, ArrayKey } from '@/types/utils';
 
-function withPrimitiveProperties<Schema extends HttpSearchParamsSchema>(searchParamsInit: Schema) {
+import { HttpSearchParamsSchema, HttpSearchParamsSchemaTuple } from './types';
+
+function pickDefinedPrimitiveProperties<Schema extends HttpSearchParamsSchema>(searchParamsInit: Schema) {
   return Object.entries(searchParamsInit).reduce<Record<string, string>>((accumulated, [key, value]) => {
     if (value !== undefined && !Array.isArray(value)) {
       accumulated[key] = value;
@@ -9,20 +11,14 @@ function withPrimitiveProperties<Schema extends HttpSearchParamsSchema>(searchPa
   }, {});
 }
 
-export interface HttpSearchParamsSchema {
-  [paramName: string]: string | string[] | undefined;
-}
-
-type HttpSearchParamsSchemaTuple<Schema extends HttpSearchParamsSchema> = {
-  [Key in keyof Schema & string]: [Key, ArrayItemIfArray<Defined<Schema[Key]>>];
-}[keyof Schema & string];
-
 class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends URLSearchParams {
-  constructor(init?: URLSearchParams | HttpSearchParams<Schema> | HttpSearchParamsSchemaTuple<Schema>[] | Schema) {
-    if (init instanceof URLSearchParams || Array.isArray(init) || !init) {
+  constructor(
+    init?: string | URLSearchParams | Schema | HttpSearchParams<Schema> | HttpSearchParamsSchemaTuple<Schema>[],
+  ) {
+    if (init instanceof URLSearchParams || Array.isArray(init) || typeof init === 'string' || !init) {
       super(init);
     } else {
-      super(withPrimitiveProperties(init));
+      super(pickDefinedPrimitiveProperties(init));
       this.populateInitArrayProperties(init);
     }
   }

--- a/packages/zimic/src/interceptor/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/HttpSearchParams.ts
@@ -1,0 +1,100 @@
+import { ReplaceBy, Defined, ArrayItemIfArray, NonArrayKey, ArrayKey } from '@/types/utils';
+
+function withPrimitiveProperties<Schema extends HttpSearchParamsSchema>(searchParamsInit: Schema) {
+  return Object.entries(searchParamsInit).reduce<Record<string, string>>((accumulated, [key, value]) => {
+    if (value !== undefined && !Array.isArray(value)) {
+      accumulated[key] = value;
+    }
+    return accumulated;
+  }, {});
+}
+
+export interface HttpSearchParamsSchema {
+  [paramName: string]: string | string[] | undefined;
+}
+
+type HttpSearchParamsSchemaTuple<Schema extends HttpSearchParamsSchema> = {
+  [Key in keyof Schema & string]: [Key, ArrayItemIfArray<Defined<Schema[Key]>>];
+}[keyof Schema & string];
+
+class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends URLSearchParams {
+  constructor(init?: URLSearchParams | HttpSearchParams<Schema> | HttpSearchParamsSchemaTuple<Schema>[] | Schema) {
+    if (init instanceof URLSearchParams || Array.isArray(init) || !init) {
+      super(init);
+    } else {
+      super(withPrimitiveProperties(init));
+      this.populateInitArrayProperties(init);
+    }
+  }
+
+  private populateInitArrayProperties(init: Schema) {
+    for (const [key, value] of Object.entries(init)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          super.append(key, item);
+        }
+      }
+    }
+  }
+
+  set<Name extends keyof Schema & string>(name: Name, value: ArrayItemIfArray<Defined<Schema[Name]>>): void {
+    super.set(name, value);
+  }
+
+  append<Name extends keyof Schema & string>(name: Name, value: ArrayItemIfArray<Defined<Schema[Name]>>): void {
+    super.append(name, value);
+  }
+
+  get<Name extends NonArrayKey<Schema> & string>(
+    name: Name,
+  ): ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null> {
+    return super.get(name) as ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null>;
+  }
+
+  getAll<Name extends ArrayKey<Schema> & string>(name: Name): ArrayItemIfArray<Defined<Schema[Name]>>[] {
+    return super.getAll(name) as ArrayItemIfArray<Defined<Schema[Name]>>[];
+  }
+
+  has<Name extends keyof Schema & string>(name: Name, value?: ArrayItemIfArray<Defined<Schema[Name]>>): boolean {
+    return super.has(name, value);
+  }
+
+  delete<Name extends keyof Schema & string>(name: Name, value?: ArrayItemIfArray<Defined<Schema[Name]>>): void {
+    super.delete(name, value);
+  }
+
+  forEach<This extends HttpSearchParams<Schema>>(
+    callback: <Key extends keyof Schema & string>(
+      value: ArrayItemIfArray<Defined<Schema[Key]>>,
+      key: Key,
+      parent: HttpSearchParams<Schema>,
+    ) => void,
+    thisArg?: This,
+  ): void {
+    super.forEach(callback as (value: string, key: string, parent: URLSearchParams) => void, thisArg);
+  }
+
+  keys(): IterableIterator<keyof Schema & string> {
+    return super.keys() as IterableIterator<keyof Schema & string>;
+  }
+
+  values(): IterableIterator<ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>> {
+    return super.values() as IterableIterator<ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>>;
+  }
+
+  entries(): IterableIterator<[keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]> {
+    return super.entries() as IterableIterator<
+      [keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]
+    >;
+  }
+
+  [Symbol.iterator](): IterableIterator<
+    [keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]
+  > {
+    return super[Symbol.iterator]() as IterableIterator<
+      [keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]
+    >;
+  }
+}
+
+export default HttpSearchParams;

--- a/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -171,14 +171,14 @@ describe('HttpSearchParams', () => {
     expectTypeOf(names).toEqualTypeOf<string[]>();
     expect(names).toEqual(['User1', 'User2']);
 
-    // @ts-expect-error
+    // @ts-expect-error `get` not allow accessing array keys
     searchParams.get('names');
 
     const page = searchParams.get('page');
     expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
     expect(page).toBe('1');
 
-    // @ts-expect-error
+    // @ts-expect-error `getAll` not allow accessing non-array keys
     searchParams.getAll('page');
   });
 

--- a/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -81,6 +81,16 @@ describe('HttpSearchParams', () => {
   });
 
   it('should support being created by search param tuples', () => {
+    new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>([
+      // @ts-expect-error The first tuple item should match one of the declared keys
+      ['unknown', '1'],
+      // @ts-expect-error The second tuple item should match the type of the key value
+      ['page', 'non-number'],
+    ]);
+
     const searchParams = new HttpSearchParams<{
       names?: string[];
       page?: `${number}`;

--- a/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -9,6 +9,8 @@ describe('HttpSearchParams', () => {
       page?: `${number}`;
     }>(new URLSearchParams('names=User1&names=User2&page=1'));
 
+    expect(searchParams.size).toBe(3);
+
     const names = searchParams.getAll('names');
     expectTypeOf(names).toEqualTypeOf<string[]>();
     expect(names).toEqual(['User1', 'User2']);
@@ -23,6 +25,8 @@ describe('HttpSearchParams', () => {
       names?: string[];
       page?: `${number}`;
     }>('names=User1&names=User2&page=1');
+
+    expect(searchParams.size).toBe(3);
 
     const names = searchParams.getAll('names');
     expectTypeOf(names).toEqualTypeOf<string[]>();
@@ -41,6 +45,8 @@ describe('HttpSearchParams', () => {
       names: ['User1', 'User2'],
       page: '1',
     });
+
+    expect(searchParams.size).toBe(3);
 
     const names = searchParams.getAll('names');
     expectTypeOf(names).toEqualTypeOf<string[]>();
@@ -63,6 +69,8 @@ describe('HttpSearchParams', () => {
     const searchParams = new HttpSearchParams(otherSearchParams);
     expect(otherSearchParams).toEqual(searchParams);
 
+    expect(searchParams.size).toBe(3);
+
     const names = searchParams.getAll('names');
     expectTypeOf(names).toEqualTypeOf<string[]>();
     expect(names).toEqual(['User1', 'User2']);
@@ -82,6 +90,8 @@ describe('HttpSearchParams', () => {
       ['page', '1'],
     ]);
 
+    expect(searchParams.size).toBe(3);
+
     const names = searchParams.getAll('names');
     expectTypeOf(names).toEqualTypeOf<string[]>();
     expect(names).toEqual(['User1', 'User2']);
@@ -97,9 +107,16 @@ describe('HttpSearchParams', () => {
       page?: `${number}`;
     }>();
 
+    expect(searchParams.size).toBe(0);
+
     searchParams.set('names', 'User1');
+    expect(searchParams.size).toBe(1);
+
     searchParams.set('names', 'User2');
+    expect(searchParams.size).toBe(1);
+
     searchParams.set('page', '1');
+    expect(searchParams.size).toBe(2);
 
     expect(searchParams.getAll('names')).toEqual(['User2']);
     expect(searchParams.get('page')).toBe('1');
@@ -111,9 +128,16 @@ describe('HttpSearchParams', () => {
       page?: `${number}`;
     }>();
 
+    expect(searchParams.size).toBe(0);
+
     searchParams.append('names', 'User1');
+    expect(searchParams.size).toBe(1);
+
     searchParams.append('names', 'User2');
+    expect(searchParams.size).toBe(2);
+
     searchParams.append('page', '1');
+    expect(searchParams.size).toBe(3);
 
     const names = searchParams.getAll('names');
     expectTypeOf(names).toEqualTypeOf<string[]>();
@@ -181,16 +205,24 @@ describe('HttpSearchParams', () => {
       page: '1',
     });
 
+    expect(searchParams.size).toBe(3);
+
     searchParams.delete('names');
+    expect(searchParams.size).toBe(1);
     expect(searchParams.getAll('names')).toEqual([]);
 
     searchParams.append('names', 'User1');
+    expect(searchParams.size).toBe(2);
+
     searchParams.append('names', 'User2');
+    expect(searchParams.size).toBe(3);
 
     searchParams.delete('names', 'User1');
+    expect(searchParams.size).toBe(2);
     expect(searchParams.getAll('names')).toEqual(['User2']);
 
     searchParams.delete('page');
+    expect(searchParams.size).toBe(1);
     expect(searchParams.get('page')).toBe(null);
   });
 

--- a/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import HttpSearchParams from '../HttpSearchParams';
+
+describe('HttpSearchParams', () => {
+  it('should support being created from raw URLSearchParams', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>(new URLSearchParams('names=User1&names=User2&page=1'));
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+  });
+
+  it('should support being created from a string', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>('names=User1&names=User2&page=1');
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+  });
+
+  it('should support being created from an object', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+  });
+
+  it('should support being created from another HttpSearchParams', () => {
+    const otherSearchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const searchParams = new HttpSearchParams(otherSearchParams);
+    expect(otherSearchParams).toEqual(searchParams);
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+  });
+
+  it('should support being created by search param tuples', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>([
+      ['names', 'User1'],
+      ['names', 'User2'],
+      ['page', '1'],
+    ]);
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+  });
+
+  it('should support setting params', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>();
+
+    searchParams.set('names', 'User1');
+    searchParams.set('names', 'User2');
+    searchParams.set('page', '1');
+
+    expect(searchParams.getAll('names')).toEqual(['User2']);
+    expect(searchParams.get('page')).toBe('1');
+  });
+
+  it('should support appending params', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>();
+
+    searchParams.append('names', 'User1');
+    searchParams.append('names', 'User2');
+    searchParams.append('page', '1');
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+  });
+
+  it('should support getting params', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const names = searchParams.getAll('names');
+    expectTypeOf(names).toEqualTypeOf<string[]>();
+    expect(names).toEqual(['User1', 'User2']);
+
+    // @ts-expect-error
+    searchParams.get('names');
+
+    const page = searchParams.get('page');
+    expectTypeOf(page).toEqualTypeOf<`${number}` | null>();
+    expect(page).toBe('1');
+
+    // @ts-expect-error
+    searchParams.getAll('page');
+  });
+
+  it('should support checking if params exist', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+      other?: string;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    expect(searchParams.has('names')).toBe(true);
+
+    expect(searchParams.has('names', 'User1')).toBe(true);
+    expect(searchParams.has('names', 'User2')).toBe(true);
+    expect(searchParams.has('names', 'User3')).toBe(false);
+
+    expect(searchParams.has('page')).toBe(true);
+    expect(searchParams.has('page', '1')).toBe(true);
+    expect(searchParams.has('page', '2')).toBe(false);
+
+    expect(searchParams.has('other')).toBe(false);
+    expect(searchParams.has('other', '1')).toBe(false);
+  });
+
+  it('should support deleting params', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    searchParams.delete('names');
+    expect(searchParams.getAll('names')).toEqual([]);
+
+    searchParams.append('names', 'User1');
+    searchParams.append('names', 'User2');
+
+    searchParams.delete('names', 'User1');
+    expect(searchParams.getAll('names')).toEqual(['User2']);
+
+    searchParams.delete('page');
+    expect(searchParams.get('page')).toBe(null);
+  });
+
+  it('should support iterating over params', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const entries = Array.from(searchParams);
+    expectTypeOf(entries).toEqualTypeOf<['names' | 'page', string][]>();
+
+    expect(entries).toHaveLength(3);
+    expect(entries).toContainEqual(['names', 'User1']);
+    expect(entries).toContainEqual(['names', 'User2']);
+    expect(entries).toContainEqual(['page', '1']);
+  });
+
+  it('should support iterating over params using `forEach`', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const entries: string[][] = [];
+
+    searchParams.forEach((value, key) => {
+      entries.push([key, value]);
+    });
+
+    expect(entries).toHaveLength(3);
+    expect(entries).toContainEqual(['names', 'User1']);
+    expect(entries).toContainEqual(['names', 'User2']);
+    expect(entries).toContainEqual(['page', '1']);
+  });
+
+  it('should support getting keys', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const keys = Array.from(searchParams.keys());
+    expectTypeOf(keys).toEqualTypeOf<('names' | 'page')[]>();
+    expect(keys).toHaveLength(3);
+    expect(keys).toEqual(expect.arrayContaining(['names', 'names', 'page']));
+  });
+
+  it('should support getting values', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const values = Array.from(searchParams.values());
+    expectTypeOf(values).toEqualTypeOf<string[]>();
+    expect(values).toHaveLength(3);
+    expect(values).toEqual(expect.arrayContaining(['User1', 'User2', '1']));
+  });
+
+  it('should support getting entries', () => {
+    const searchParams = new HttpSearchParams<{
+      names?: string[];
+      page?: `${number}`;
+    }>({
+      names: ['User1', 'User2'],
+      page: '1',
+    });
+
+    const entries = Array.from(searchParams.entries());
+    expectTypeOf(entries).toEqualTypeOf<['names' | 'page', string][]>();
+    expect(entries).toHaveLength(3);
+    expect(entries).toContainEqual(['names', 'User1']);
+    expect(entries).toContainEqual(['names', 'User2']);
+    expect(entries).toContainEqual(['page', '1']);
+  });
+});

--- a/packages/zimic/src/interceptor/http/searchParams/types.ts
+++ b/packages/zimic/src/interceptor/http/searchParams/types.ts
@@ -1,0 +1,9 @@
+import { Defined, ArrayItemIfArray } from '@/types/utils';
+
+export interface HttpSearchParamsSchema {
+  [paramName: string]: string | string[] | undefined;
+}
+
+export type HttpSearchParamsSchemaTuple<Schema extends HttpSearchParamsSchema> = {
+  [Key in keyof Schema & string]: [Key, ArrayItemIfArray<Defined<Schema[Key]>>];
+}[keyof Schema & string];

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -1,6 +1,7 @@
 import InvalidHttpInterceptorWorkerPlatform from './http/interceptorWorker/errors/InvalidHttpInterceptorWorkerPlatform';
 import NotStartedHttpInterceptorWorkerError from './http/interceptorWorker/errors/NotStartedHttpInterceptorWorkerError';
 import UnregisteredServiceWorkerError from './http/interceptorWorker/errors/UnregisteredServiceWorkerError';
+import HttpSearchParams from './http/searchParams/HttpSearchParams';
 
 export type { HttpInterceptorWorker } from './http/interceptorWorker/types/public';
 export type { HttpInterceptorWorkerOptions } from './http/interceptorWorker/types/options';
@@ -21,11 +22,17 @@ export type {
 
 export type { HttpRequestTracker } from './http/requestTracker/types/public';
 
+export type { HttpSearchParamsSchema, HttpSearchParamsSchemaTuple } from './http/searchParams/types';
+
+export { HttpSearchParams };
+
 export type { HttpInterceptorOptions } from './http/interceptor/types/options';
 
 export type {
   HttpInterceptorMethod,
   HttpInterceptorRequestSchema,
+  HttpInterceptorSearchParamsSchema,
+  HttpInterceptorBodySchema,
   HttpInterceptorResponseSchema,
   HttpInterceptorResponseSchemaByStatusCode,
   HttpInterceptorResponseSchemaStatusCode,

--- a/packages/zimic/src/types/utils.ts
+++ b/packages/zimic/src/types/utils.ts
@@ -17,3 +17,21 @@ export type UnionToIntersection<Union> = (Union extends unknown ? (union: Union)
 export type Prettify<Type> = {
   [Key in keyof Type]: Type[Key];
 };
+
+export type NonUndefined<Type> = Exclude<Type, undefined>;
+
+export type NonNullable<Type> = Exclude<Type, null>;
+
+export type Defined<Type> = NonNullable<NonUndefined<Type>>;
+
+export type ArrayItemIfArray<Type> = Type extends (infer Item)[] ? Item : Type;
+
+type PickArrayProperties<Type> = {
+  [Key in keyof Type as never[] extends Type[Key] ? Key : never]: Type[Key];
+};
+
+export type ArrayKey<Type> = keyof PickArrayProperties<Type>;
+
+export type NonArrayKey<Type> = Exclude<keyof Type, ArrayKey<Type>>;
+
+export type ReplaceBy<Type, Source, Target> = Type extends Source ? Target : Type;


### PR DESCRIPTION
### Features
- [#zimic] Added support to request search params.

### Tests
- [zimic-test-client] Extended the default tests to also verify search params.

Closes #84.
