### PR TITLE
build: upgrade vite and `@types/node`

### DIFF
--- a/apps/zimic-test-client/package.json
+++ b/apps/zimic-test-client/package.json
@@ -21,7 +21,6 @@
     "zimic0": "workspace:zimic@*"
   },
   "devDependencies": {
-    "@types/node": "^18.8.4",
     "@types/superagent": "^8.1.3",
     "@vitest/browser": "^1.2.1",
     "@vitest/coverage-istanbul": "^1.2.1",

--- a/examples/with-jest-jsdom/package.json
+++ b/examples/with-jest-jsdom/package.json
@@ -17,7 +17,6 @@
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/user-event": "^14.5.2",
-    "@types/node": "^18.8.4",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "typescript": "^5.3.3"

--- a/examples/with-jest-node/package.json
+++ b/examples/with-jest-node/package.json
@@ -16,7 +16,6 @@
     "@jest/globals": "^29.7.0",
     "@swc/core": "^1.4.1",
     "@swc/jest": "^0.2.36",
-    "@types/node": "^18.8.4",
     "@types/supertest": "^6.0.2",
     "jest": "^29.7.0",
     "supertest": "^6.3.4",

--- a/examples/with-vitest-browser/package.json
+++ b/examples/with-vitest-browser/package.json
@@ -17,7 +17,6 @@
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/user-event": "^14.5.2",
-    "@types/node": "^18.8.4",
     "@vitest/browser": "^1.2.1",
     "playwright": "^1.41.0",
     "typescript": "^5.3.3",

--- a/examples/with-vitest-jsdom/package.json
+++ b/examples/with-vitest-jsdom/package.json
@@ -14,7 +14,6 @@
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/user-event": "^14.5.2",
-    "@types/node": "^18.8.4",
     "typescript": "^5.3.3",
     "vitest": "^1.1.2"
   }

--- a/examples/with-vitest-node/package.json
+++ b/examples/with-vitest-node/package.json
@@ -13,7 +13,6 @@
     "zod": "^3.22.3"
   },
   "devDependencies": {
-    "@types/node": "^18.8.4",
     "@types/supertest": "^6.0.2",
     "supertest": "^6.3.4",
     "typescript": "^5.3.3",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -36,13 +36,13 @@
     "zx": "^4.2.0"
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
+    "@types/node": "^20.11.20",
+    "@types/yargs": "^17.0.32",
     "@vitest/coverage-istanbul": "^1.2.1",
     "@zimic/eslint-config-node": "workspace:*",
     "@zimic/lint-staged-config": "workspace:*",
     "@zimic/tsconfig": "workspace:*",
-    "@types/fs-extra": "^9.0.13",
-    "@types/node": "^18.8.4",
-    "@types/yargs": "^17.0.32",
     "dotenv-cli": "^7.0.0",
     "tsup": "^8.0.1",
     "tsx": "^4.6.0",

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -80,7 +80,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@types/node": "^18.8.4",
+    "@types/node": "^20.11.20",
     "@types/yargs": "^17.0.32",
     "@vitest/browser": "^1.2.1",
     "@vitest/coverage-istanbul": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+        version: 1.2.0(@types/node@18.19.6)
 
   examples/with-vitest-node:
     dependencies:
@@ -263,7 +263,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+        version: 1.2.0(@types/node@18.19.6)
 
   packages/eslint-config:
     dependencies:
@@ -357,7 +357,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+        version: 1.2.0(@types/node@18.19.6)
 
   packages/tsconfig:
     dependencies:
@@ -6350,6 +6350,15 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -7591,7 +7600,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.11(@types/node@18.19.6)
+      vite: 5.1.4(@types/node@18.19.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7639,6 +7648,99 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vite@5.1.4(@types/node@18.19.6):
+    resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.6
+      esbuild: 0.19.11
+      postcss: 8.4.35
+      rollup: 4.9.5
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.2.0(@types/node@18.19.6):
+    resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.6
+      '@vitest/expect': 1.2.0
+      '@vitest/runner': 1.2.0
+      '@vitest/snapshot': 1.2.0
+      '@vitest/spy': 1.2.0
+      '@vitest/utils': 1.2.0
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.1
+      vite: 5.0.11(@types/node@18.19.6)
+      vite-node: 1.2.0(@types/node@18.19.6)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vitest@1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1):
     resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7684,7 +7786,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.1
-      vite: 5.0.11(@types/node@18.19.6)
+      vite: 5.1.4(@types/node@18.19.6)
       vite-node: 1.2.0(@types/node@18.19.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.4.4
-        version: 18.4.4(@types/node@18.19.6)(typescript@5.3.3)
+        version: 18.4.4(@types/node@20.11.20)(typescript@5.3.3)
       '@commitlint/config-conventional':
         specifier: ^18.4.4
         version: 18.4.4
@@ -45,9 +45,6 @@ importers:
         specifier: workspace:zimic@*
         version: link:../../packages/zimic
     devDependencies:
-      '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
       '@types/superagent':
         specifier: ^8.1.3
         version: 8.1.3
@@ -86,7 +83,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+        version: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
 
   examples:
     dependencies:
@@ -131,12 +128,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@9.3.4)
-      '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.6)
+        version: 29.7.0(@types/node@20.11.20)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -165,15 +159,12 @@ importers:
       '@swc/jest':
         specifier: ^0.2.36
         version: 0.2.36(@swc/core@1.4.1)
-      '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.6)
+        version: 29.7.0(@types/node@20.11.20)
       supertest:
         specifier: ^6.3.4
         version: 6.3.4
@@ -196,9 +187,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@9.3.4)
-      '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
       '@vitest/browser':
         specifier: ^1.2.1
         version: 1.2.1(playwright@1.41.0)(vitest@1.2.0)
@@ -210,7 +198,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+        version: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
 
   examples/with-vitest-jsdom:
     dependencies:
@@ -227,15 +215,12 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@9.3.4)
-      '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)
+        version: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
 
   examples/with-vitest-node:
     dependencies:
@@ -249,9 +234,6 @@ importers:
         specifier: ^3.22.3
         version: 3.22.4
     devDependencies:
-      '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2
@@ -263,7 +245,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)
+        version: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
 
   packages/eslint-config:
     dependencies:
@@ -326,8 +308,8 @@ importers:
         specifier: ^9.0.13
         version: 9.0.13
       '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
+        specifier: ^20.11.20
+        version: 20.11.20
       '@types/yargs':
         specifier: ^17.0.32
         version: 17.0.32
@@ -357,7 +339,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)
+        version: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
 
   packages/tsconfig:
     dependencies:
@@ -378,8 +360,8 @@ importers:
         version: 17.7.2
     devDependencies:
       '@types/node':
-        specifier: ^18.8.4
-        version: 18.19.6
+        specifier: ^20.11.20
+        version: 20.11.20
       '@types/yargs':
         specifier: ^17.0.32
         version: 17.0.32
@@ -412,7 +394,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.1.2
-        version: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+        version: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
 
 packages:
 
@@ -781,14 +763,14 @@ packages:
       statuses: 2.0.1
     dev: false
 
-  /@commitlint/cli@18.4.4(@types/node@18.19.6)(typescript@5.3.3):
+  /@commitlint/cli@18.4.4(@types/node@20.11.20)(typescript@5.3.3):
     resolution: {integrity: sha512-Ro3wIo//fV3XiV1EkdpHog6huaEyNcUAVrSmtgKqYM5g982wOWmP4FXvEDFwRMVgz878CNBvvCc33dMZ5AQJ/g==}
     engines: {node: '>=v18'}
     hasBin: true
     dependencies:
       '@commitlint/format': 18.4.4
       '@commitlint/lint': 18.4.4
-      '@commitlint/load': 18.4.4(@types/node@18.19.6)(typescript@5.3.3)
+      '@commitlint/load': 18.4.4(@types/node@20.11.20)(typescript@5.3.3)
       '@commitlint/read': 18.4.4
       '@commitlint/types': 18.4.4
       execa: 5.1.1
@@ -859,7 +841,7 @@ packages:
       '@commitlint/types': 18.4.4
     dev: true
 
-  /@commitlint/load@18.4.4(@types/node@18.19.6)(typescript@5.3.3):
+  /@commitlint/load@18.4.4(@types/node@20.11.20)(typescript@5.3.3):
     resolution: {integrity: sha512-RaDIa9qwOw2xRJ3Jr2DBXd14rmnHJIX2XdZF4kmoF1rgsg/+7cvrExLSUNAkQUNimyjCn1b/bKX2Omm+GdY0XQ==}
     engines: {node: '>=v18'}
     dependencies:
@@ -869,7 +851,7 @@ packages:
       '@commitlint/types': 18.4.4
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.3.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.19.6)(cosmiconfig@8.3.6)(typescript@5.3.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.20)(cosmiconfig@8.3.6)(typescript@5.3.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -1266,7 +1248,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -1287,14 +1269,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.6)
+      jest-config: 29.7.0(@types/node@20.11.20)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -1329,7 +1311,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       jest-mock: 29.7.0
     dev: true
 
@@ -1356,7 +1338,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -1389,7 +1371,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.21
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -1477,7 +1459,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -1875,7 +1857,7 @@ packages:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
-      jest: 29.7.0(@types/node@18.19.6)
+      jest: 29.7.0(@types/node@20.11.20)
       lodash: 4.17.21
       redent: 3.0.0
     dev: true
@@ -1909,7 +1891,7 @@ packages:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
-      vitest: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+      vitest: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
     dev: true
 
   /@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4):
@@ -1980,12 +1962,12 @@ packages:
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
 
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -2007,7 +1989,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
     dev: true
@@ -2040,7 +2022,7 @@ packages:
   /@types/node-fetch@2.6.10:
     resolution: {integrity: sha512-PPpPK6F9ALFTn59Ka3BaL+qGuipRfxNE8qVgkp0bVixeiR2c2/L+IVOiBdu9JhhT22sWnQEp6YyHGI2b2+CMcA==}
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       form-data: 4.0.0
     dev: false
 
@@ -2048,8 +2030,8 @@ packages:
     resolution: {integrity: sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg==}
     dev: false
 
-  /@types/node@18.19.6:
-    resolution: {integrity: sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==}
+  /@types/node@20.11.20:
+    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
     dependencies:
       undici-types: 5.26.5
 
@@ -2074,7 +2056,7 @@ packages:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
     dev: true
 
   /@types/supertest@6.0.2:
@@ -2257,7 +2239,7 @@ packages:
       magic-string: 0.30.5
       playwright: 1.41.0
       sirv: 2.0.4
-      vitest: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+      vitest: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
     dev: true
 
   /@vitest/coverage-istanbul@1.2.1(vitest@1.2.0):
@@ -2274,7 +2256,7 @@ packages:
       magicast: 0.3.3
       picocolors: 1.0.0
       test-exclude: 6.0.0
-      vitest: 1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1)
+      vitest: 1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3036,7 +3018,7 @@ packages:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
     dev: true
 
-  /cosmiconfig-typescript-loader@5.0.0(@types/node@18.19.6)(cosmiconfig@8.3.6)(typescript@5.3.3):
+  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.20)(cosmiconfig@8.3.6)(typescript@5.3.3):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -3044,7 +3026,7 @@ packages:
       cosmiconfig: '>=8.2'
       typescript: '>=4'
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       cosmiconfig: 8.3.6(typescript@5.3.3)
       jiti: 1.21.0
       typescript: 5.3.3
@@ -3066,7 +3048,7 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /create-jest@29.7.0(@types/node@18.19.6):
+  /create-jest@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3075,7 +3057,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.6)
+      jest-config: 29.7.0(@types/node@20.11.20)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4799,7 +4781,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -4820,7 +4802,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@18.19.6):
+  /jest-cli@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -4834,10 +4816,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.6)
+      create-jest: 29.7.0(@types/node@20.11.20)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.6)
+      jest-config: 29.7.0(@types/node@20.11.20)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4848,7 +4830,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@18.19.6):
+  /jest-config@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -4863,7 +4845,7 @@ packages:
       '@babel/core': 7.23.7
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       babel-jest: 29.7.0(@babel/core@7.23.7)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -4929,7 +4911,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -4946,7 +4928,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -4962,7 +4944,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5013,7 +4995,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       jest-util: 29.7.0
     dev: true
 
@@ -5068,7 +5050,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5099,7 +5081,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -5151,7 +5133,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5176,7 +5158,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5188,13 +5170,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0(@types/node@18.19.6):
+  /jest@29.7.0(@types/node@20.11.20):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -5207,7 +5189,7 @@ packages:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.6)
+      jest-cli: 29.7.0(@types/node@20.11.20)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -7591,7 +7573,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@1.2.0(@types/node@18.19.6):
+  /vite-node@1.2.0(@types/node@20.11.20):
     resolution: {integrity: sha512-ETnQTHeAbbOxl7/pyBck9oAPZZZo+kYnFt1uQDD+hPReOc+wCjXw4r4jHriBRuVDB5isHmPXxrfc1yJnfBERqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7600,7 +7582,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.4(@types/node@18.19.6)
+      vite: 5.1.4(@types/node@20.11.20)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7612,7 +7594,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.0.11(@types/node@18.19.6):
+  /vite@5.0.11(@types/node@20.11.20):
     resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7640,7 +7622,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.9.5
@@ -7648,7 +7630,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.1.4(@types/node@18.19.6):
+  /vite@5.1.4(@types/node@20.11.20):
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7676,7 +7658,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       esbuild: 0.19.11
       postcss: 8.4.35
       rollup: 4.9.5
@@ -7684,7 +7666,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.0(@types/node@18.19.6):
+  /vitest@1.2.0(@types/node@20.11.20)(@vitest/browser@1.2.1):
     resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -7709,64 +7691,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 18.19.6
-      '@vitest/expect': 1.2.0
-      '@vitest/runner': 1.2.0
-      '@vitest/snapshot': 1.2.0
-      '@vitest/spy': 1.2.0
-      '@vitest/utils': 1.2.0
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.4.1
-      debug: 4.3.4
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.8.1
-      vite: 5.0.11(@types/node@18.19.6)
-      vite-node: 1.2.0(@types/node@18.19.6)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest@1.2.0(@types/node@18.19.6)(@vitest/browser@1.2.1):
-    resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 18.19.6
+      '@types/node': 20.11.20
       '@vitest/browser': 1.2.1(playwright@1.41.0)(vitest@1.2.0)
       '@vitest/expect': 1.2.0
       '@vitest/runner': 1.2.0
@@ -7786,8 +7711,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.1
-      vite: 5.1.4(@types/node@18.19.6)
-      vite-node: 1.2.0(@types/node@18.19.6)
+      vite: 5.0.11(@types/node@20.11.20)
+      vite-node: 1.2.0(@types/node@20.11.20)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
### Build
- [root] Upgrade `vite` and `@types/node` to their latest versions.
- [root] Remove unnecessary `@types/node` from packages that do not need it.

Also solves https://github.com/diego-aquino/zimic/security/dependabot/1.