### PR TITLE
docs: v0.2.0 (#23)

### DIFF
--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -17,6 +17,11 @@ export type HttpHeadersInit<Schema extends HttpHeadersSchema> =
   | HttpHeaders<Schema>
   | HttpHeadersSchemaTuple<Schema>[];
 
+/**
+ * A superset of the built-in {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} with strict types. This
+ * class is fully compatible with {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} and can be used as a
+ * drop-in replacement.
+ */
 class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends Headers {
   constructor(init?: HttpHeadersInit<Schema>) {
     if (init instanceof Headers || Array.isArray(init) || !init) {

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -1,9 +1,11 @@
 import { Defined } from '@/types/utils';
 
+/** A schema for strict HTTP headers. */
 export interface HttpHeadersSchema {
-  [paramName: string]: string | undefined;
+  [headerName: string]: string | undefined;
 }
 
+/** A strict tuple representation of a {@link HttpHeadersSchema}. */
 export type HttpHeadersSchemaTuple<Schema extends HttpHeadersSchema> = {
   [Key in keyof Schema & string]: [Key, Defined<Schema[Key]>];
 }[keyof Schema & string];

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -15,6 +15,12 @@ function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(schema: 
   return schemaWithPrimitiveProperties;
 }
 
+/**
+ * A superset of the built-in {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} with
+ * strict types. This class is fully compatible with
+ * {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} and can be used as a drop-in
+ * replacement.
+ */
 class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends URLSearchParams {
   constructor(
     init?: string | URLSearchParams | Schema | HttpSearchParams<Schema> | HttpSearchParamsSchemaTuple<Schema>[],

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -1,9 +1,11 @@
 import { Defined, ArrayItemIfArray } from '@/types/utils';
 
+/** A schema for strict HTTP URL search parameters. */
 export interface HttpSearchParamsSchema {
   [paramName: string]: string | string[] | undefined;
 }
 
+/** A strict tuple representation of a {@link HttpSearchParamsSchema}. */
 export type HttpSearchParamsSchemaTuple<Schema extends HttpSearchParamsSchema> = {
   [Key in keyof Schema & string]: [Key, ArrayItemIfArray<Defined<Schema[Key]>>];
 }[keyof Schema & string];

--- a/packages/zimic/src/types/json.ts
+++ b/packages/zimic/src/types/json.ts
@@ -1,3 +1,4 @@
+/** Value that can be represented in JSON. */
 export type JSONValue =
   | {
       [Key in never]: JSONValue;


### PR DESCRIPTION
### Documentation
- [#zimic] Documented `HttpHeaders`, `HttpSearchParams`, and `JSONValue`.

Closes #23.
