### PR TITLE
docs: v0.2.0 (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,9 +636,9 @@ const interceptor = createHttpInterceptor<{
 Each method can have a `request`, which defines the schema of the accepted requests. `headers`, `searchParams`, and
 `body` are supported to provide type safety when applying mocks.
 
-> **Tip**: You need to declare only the properties you want to use in your mocks. For example, if you will reference
-> only the header `accept`, you can declare only it. Similarly, if you won't use any headers, search params, or body,
-> you can omit their properties.
+> **Tip**: You only need to declare the properties you want to use in your mocks. For example, if you are referencing
+> only the header `accept`, you need to declare only it. Similarly, if you are not using any headers, search params, or
+> body, you can omit them.
 
 ```ts
 import { createHttpInterceptor } from 'zimic/interceptor';
@@ -712,9 +712,9 @@ const interceptor = createHttpInterceptor<{
 Each method can also have a `response`, which defines the schema of the returned responses. The status codes are used as
 keys. `headers` and `body` are supported to provide type safety when applying mocks.
 
-> **Tip**: Similarly to [Declaring requests](#declaring-requests), you need to declare only the properties you want to
-> use in your mocks. For example, if you will reference only the header `content-type`, you can declare only it. If you
-> won't use any headers or body, you can omit their properties.
+> **Tip**: Similarly to [Declaring requests](#declaring-requests), you only need to declare the properties you want to
+> use in your mocks. For example, if you are referencing only the header `content-type`, you can declare only it. If you
+> are not using any headers or body, you can omit them.
 
 ```ts
 import { createHttpInterceptor } from 'zimic/interceptor';

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Visit our [examples](./examples) to see how to use Zimic with popular frameworks
 To start using Zimic, create a [worker](#httpinterceptorworker) targeting your platform.
 
 ```ts
+import { createHttpInterceptorWorker } from 'zimic/interceptor';
+
 const worker = createHttpInterceptorWorker({
   platform: 'node', // or 'browser'
 });
@@ -159,6 +161,8 @@ const worker = createHttpInterceptorWorker({
 Then, create your first [interceptor](#httpinterceptor):
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users': {
     GET: {
@@ -266,6 +270,8 @@ Creates an HTTP interceptor worker. A platform is required to specify the enviro
 - Node.js:
 
   ```ts
+  import { createHttpInterceptorWorker } from 'zimic/interceptor';
+
   const worker = createHttpInterceptorWorker({
     platform: 'node',
   });
@@ -274,6 +280,8 @@ Creates an HTTP interceptor worker. A platform is required to specify the enviro
 - Browser:
 
   ```ts
+  import { createHttpInterceptorWorker } from 'zimic/interceptor';
+
   const worker = createHttpInterceptorWorker({
     platform: 'browser',
   });
@@ -360,6 +368,8 @@ mocks.
   <summary>An example of a complete interceptor schema:</summary>
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users': {
     POST: {
@@ -408,7 +418,7 @@ const interceptor = createHttpInterceptor<{
   <summary>Alternatively, you can compose the schema using utility types:</summary>
 
 ```ts
-import { HttpInterceptorSchema } from 'zimic/interceptor';
+import { createHttpInterceptor, HttpInterceptorSchema } from 'zimic/interceptor';
 
 type UserPaths = HttpInterceptorSchema.Root<{
   '/users': {
@@ -468,6 +478,8 @@ const interceptor = createHttpInterceptor<InterceptorSchema>({
 At the root level, each key represents a path or route:
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users': {
     // path schema
@@ -490,7 +502,7 @@ const interceptor = createHttpInterceptor<{
   </summary>
 
 ```ts
-import { HttpInterceptorSchema } from 'zimic/interceptor';
+import { createHttpInterceptor, HttpInterceptorSchema } from 'zimic/interceptor';
 
 type UserPaths = HttpInterceptorSchema.Root<{
   '/users': {
@@ -521,6 +533,8 @@ Each path can have one or more methods, (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`
 names are case-sensitive.
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users': {
     GET: {
@@ -544,7 +558,7 @@ const interceptor = createHttpInterceptor<{
   </summary>
 
 ```ts
-import { HttpInterceptorSchema } from 'zimic/interceptor';
+import { createHttpInterceptor, HttpInterceptorSchema } from 'zimic/interceptor';
 
 type UserMethods = HttpInterceptorSchema.Method<{
   GET: {
@@ -567,20 +581,39 @@ const interceptor = createHttpInterceptor<{
 
 ##### Declaring requests
 
-Each method can have a `request`, which defines the schema of the accepted requests. Currently, only the `body` property
-is supported.
+Each method can have a `request`, which defines the schema of the accepted requests. `headers`, `searchParams`, and
+`body` are supported to provide type safety when applying mocks.
+
+> **Tip**: You need to declare only the properties you want to use in your mocks. For example, if you will reference
+> only the header `accept`, you can declare only it. Similarly, if you won't use any headers, search params, or body,
+> you can omit their properties.
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users': {
     POST: {
       request: {
+        headers: {
+          accept: string;
+        };
         body: {
           username: string;
         };
       };
       // ...
     };
+
+    GET: {
+      request: {
+        searchParams: {
+          username?: string;
+        };
+      };
+      // ...
+    };
+
     // other methods
   };
   // other paths
@@ -597,9 +630,12 @@ const interceptor = createHttpInterceptor<{
   </summary>
 
 ```ts
-import { HttpInterceptorSchema } from 'zimic/interceptor';
+import { createHttpInterceptor, HttpInterceptorSchema } from 'zimic/interceptor';
 
 type UserCreationRequest = HttpInterceptorSchema.Request<{
+  headers: {
+    accept: '*/*';
+  };
   body: {
     username: string;
   };
@@ -622,16 +658,32 @@ const interceptor = createHttpInterceptor<{
 ##### Declaring responses
 
 Each method can also have a `response`, which defines the schema of the returned responses. The status codes are used as
-keys. Currently, only the `body` property is supported.
+keys. `headers` and `body` are supported to provide type safety when applying mocks.
+
+> **Tip**: Similarly to [Declaring requests](#declaring-requests), you need to declare only the properties you want to
+> use in your mocks. For example, if you will reference only the header `content-type`, you can declare only it. If you
+> won't use any headers or body, you can omit their properties.
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users/:id': {
     GET: {
       // ...
       response: {
-        200: { body: User };
-        404: { body: NotFoundError };
+        200: {
+          headers: {
+            'content-type': string;
+          };
+          body: User;
+        };
+        404: {
+          headers: {
+            'content-type': string;
+          };
+          body: NotFoundError;
+        };
       };
     };
     // other methods
@@ -650,13 +702,20 @@ const interceptor = createHttpInterceptor<{
   </summary>
 
 ```ts
-import { HttpInterceptorSchema } from 'zimic/interceptor';
+import { createHttpInterceptor, HttpInterceptorSchema } from 'zimic/interceptor';
+
 
 type SuccessUserGetResponse = HttpInterceptorSchema.Response<{
+  headers: {
+    'content-type': string;
+  };
   body: User;
 }>;
 
-type NotFoundUserGetResponse = HttpInterceptorSchema.Response<{
+type NotFoundUserGetResponse = **HttpInterceptorSchema**.Response<{
+  headers: {
+    'content-type': string;
+  };
   body: NotFoundError;
 }>;
 
@@ -698,6 +757,8 @@ declared in the interceptor schema.
 The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and `options`.
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users': {
     GET: {
@@ -724,6 +785,8 @@ Paths with dynamic path parameters, such as `/users/:id`, are supported, but you
 type parameter to get type validation.
 
 ```ts
+import { createHttpInterceptor } from 'zimic/interceptor';
+
 const interceptor = createHttpInterceptor<{
   '/users/:id': {
     PUT: {

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Zimic provides a simple, flexible and type-safe way to mock HTTP requests.
   - [Examples](#examples)
   - [Basic usage](#basic-usage)
   - [Testing](#testing)
+- [`zimic` API](#zimic-api)
+  - [`HttpHeaders`](#httpheaders)
+  - [`HttpSearchParams`](#httpsearchparams)
 - [`zimic/interceptor` API](#zimicinterceptor-api)
   - [`HttpInterceptorWorker`](#httpinterceptorworker)
     - [`createHttpInterceptorWorker`](#createhttpinterceptorworker)
@@ -248,6 +251,55 @@ afterAll(async () => {
 ```
 
 ---
+
+## `zimic` API
+
+This module provides general utilities, such as HTTP classes.
+
+### `HttpHeaders`
+
+A superset of the built-in [`Headers`](https://developer.mozilla.org/docs/Web/API/Headers) class, with a strictly-typed
+schema. `HttpHeaders` is fully compatible with `Headers` and is used by Zimic abstractions to provide type safety when
+applying mocks.
+
+```ts
+import { HttpHeaders } from 'zimic';
+
+const headers = new HttpHeaders<{
+  accept?: string;
+  'content-type'?: string;
+}>({
+  accept: '*/*',
+  'content-type': 'application/json',
+});
+
+const contentType = headers.get('content-type');
+console.log(contentType); // 'application/json'
+```
+
+### `HttpSearchParams`
+
+A superset of the built-in [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) class, with a
+strictly-typed schema. `HttpSearchParams` is fully compatible with `URLSearchParams` and is used by Zimic abstractions
+to provide type safety when applying mocks.
+
+```ts
+import { HttpSearchParams } from 'zimic';
+
+const searchParams = new HttpSearchParams<{
+  names?: string[];
+  page?: `${number}`;
+}>({
+  names: ['user 1', 'user 2'],
+  page: '1',
+});
+
+const names = searchParams.getAll('names');
+console.log(names); // ['user 1', 'user 2']
+
+const page = searchParams.get('page');
+console.log(page); // '1'
+```
 
 ## `zimic/interceptor` API
 

--- a/README.md
+++ b/README.md
@@ -925,14 +925,16 @@ A function is also supported, in case the response is dynamic:
 
 ```ts
 const listTracker = interceptor.get('/users').respond((request) => {
-  const { searchParams } = new URL(request.url);
-  const username = searchParams.get('username');
+  const username = request.searchParams.get('username');
   return {
     status: 200,
     body: [{ username }],
   };
 });
 ```
+
+The `request` parameter represents the intercepted request, containing useful properties such as `.body`, `.headers`,
+and `.searchParams`, which are typed based on the interceptor schema.
 
 #### `tracker.bypass()`
 
@@ -981,10 +983,12 @@ expect(updateRequests[0].url).toEqual('http://localhost:3000/users/1');
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-The return by `requests` contains simplified objects based on the
+The return by `requests` are simplified objects based on the
 [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
 [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) web APIs, containing an already parsed body in
-`.body`. If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
+`.body`, typed headers in `.headers` and typed search params in `.searchParams`.
+
+If you need access to the original `Request` and `Response` objects, you can use the `.raw` property:
 
 ```ts
 const listRequests = listTracker.requests();

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -17,6 +17,11 @@ export type HttpHeadersInit<Schema extends HttpHeadersSchema> =
   | HttpHeaders<Schema>
   | HttpHeadersSchemaTuple<Schema>[];
 
+/**
+ * A superset of the built-in {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} with strict types. This
+ * class is fully compatible with {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} and can be used as a
+ * drop-in replacement.
+ */
 class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends Headers {
   constructor(init?: HttpHeadersInit<Schema>) {
     if (init instanceof Headers || Array.isArray(init) || !init) {

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -18,9 +18,8 @@ export type HttpHeadersInit<Schema extends HttpHeadersSchema> =
   | HttpHeadersSchemaTuple<Schema>[];
 
 /**
- * A superset of the built-in {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} with strict types. This
- * class is fully compatible with {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} and can be used as a
- * drop-in replacement.
+ * An HTTP headers object with a strictly-typed schema. Fully compatible with the built-in
+ * {@link https://developer.mozilla.org/docs/Web/API/Headers Headers} class.
  */
 class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends Headers {
   constructor(init?: HttpHeadersInit<Schema>) {

--- a/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
@@ -25,7 +25,7 @@ describe('HttpHeaders', () => {
 
   it('should support being created from an object', () => {
     new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       // @ts-expect-error The object should match the declared schema
@@ -33,7 +33,7 @@ describe('HttpHeaders', () => {
     });
 
     new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
       // @ts-expect-error The object should match the declared schema
     }>({
@@ -41,7 +41,7 @@ describe('HttpHeaders', () => {
     });
 
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -59,7 +59,7 @@ describe('HttpHeaders', () => {
 
   it('should support being created from another HttpHeaders', () => {
     const otherHeaders = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -81,7 +81,7 @@ describe('HttpHeaders', () => {
 
   it('should support being created from header tuples', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>([
       ['accept', 'image/png'],
@@ -100,7 +100,7 @@ describe('HttpHeaders', () => {
 
   it('should support setting headers', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>();
 
@@ -123,7 +123,7 @@ describe('HttpHeaders', () => {
 
   it('should support appending headers', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>();
 
@@ -143,7 +143,7 @@ describe('HttpHeaders', () => {
 
   it('should support getting a header', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -183,7 +183,7 @@ describe('HttpHeaders', () => {
 
   it('should support checking if headers exist', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>();
 
@@ -203,7 +203,7 @@ describe('HttpHeaders', () => {
 
   it('should support deleting headers', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -221,7 +221,7 @@ describe('HttpHeaders', () => {
 
   it('should support iterating over headers', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -242,7 +242,7 @@ describe('HttpHeaders', () => {
 
   it('should support iterating over headers using `forEach`', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -266,7 +266,7 @@ describe('HttpHeaders', () => {
 
   it('should support getting keys', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -282,7 +282,7 @@ describe('HttpHeaders', () => {
 
   it('should support getting values', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',
@@ -298,7 +298,7 @@ describe('HttpHeaders', () => {
 
   it('should support getting entries', () => {
     const headers = new HttpHeaders<{
-      ['accept']?: string;
+      accept?: string;
       'content-type'?: `application/${string}`;
     }>({
       accept: '*/*',

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -1,9 +1,11 @@
 import { Defined } from '@/types/utils';
 
+/** A schema for strict HTTP headers. */
 export interface HttpHeadersSchema {
-  [paramName: string]: string | undefined;
+  [headerName: string]: string | undefined;
 }
 
+/** A strict tuple representation of a {@link HttpHeadersSchema}. */
 export type HttpHeadersSchemaTuple<Schema extends HttpHeadersSchema> = {
   [Key in keyof Schema & string]: [Key, Defined<Schema[Key]>];
 }[keyof Schema & string];

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -15,6 +15,12 @@ function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(schema: 
   return schemaWithPrimitiveProperties;
 }
 
+/**
+ * A superset of the built-in {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} with
+ * strict types. This class is fully compatible with
+ * {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} and can be used as a drop-in
+ * replacement.
+ */
 class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends URLSearchParams {
   constructor(
     init?: string | URLSearchParams | Schema | HttpSearchParams<Schema> | HttpSearchParamsSchemaTuple<Schema>[],

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -16,10 +16,8 @@ function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(schema: 
 }
 
 /**
- * A superset of the built-in {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} with
- * strict types. This class is fully compatible with
- * {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} and can be used as a drop-in
- * replacement.
+ * An HTTP search params object with a strictly-typed schema. Fully compatible with the built-in
+ * {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams URLSearchParams} class.
  */
 class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends URLSearchParams {
   constructor(

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -1,9 +1,11 @@
 import { Defined, ArrayItemIfArray } from '@/types/utils';
 
+/** A schema for strict HTTP URL search parameters. */
 export interface HttpSearchParamsSchema {
   [paramName: string]: string | string[] | undefined;
 }
 
+/** A strict tuple representation of a {@link HttpSearchParamsSchema}. */
 export type HttpSearchParamsSchemaTuple<Schema extends HttpSearchParamsSchema> = {
   [Key in keyof Schema & string]: [Key, ArrayItemIfArray<Defined<Schema[Key]>>];
 }[keyof Schema & string];

--- a/packages/zimic/src/http/types/requests.ts
+++ b/packages/zimic/src/http/types/requests.ts
@@ -6,7 +6,10 @@ import { HttpHeadersSchema } from '../headers/types';
 /** The default body type (JSON) for HTTP requests and responses. */
 export type DefaultBody = JSONValue;
 
-/** An HTTP request with a strictly-typed JSON body. */
+/**
+ * An HTTP request with a strictly-typed JSON body. Fully compatible with the built-in
+ * {@link https://developer.mozilla.org/docs/Web/API/Request Request} class.
+ */
 export interface HttpRequest<
   StrictBody extends DefaultBody = DefaultBody,
   StrictHeadersSchema extends HttpHeadersSchema = HttpHeadersSchema,
@@ -15,7 +18,10 @@ export interface HttpRequest<
   json: () => Promise<StrictBody>;
 }
 
-/** An HTTP response with a strictly-typed JSON body and status code. */
+/**
+ * An HTTP response with a strictly-typed JSON body and status code. Fully compatible with the built-in
+ * {@link https://developer.mozilla.org/docs/Web/API/Response Response} class.
+ */
 export interface HttpResponse<
   StrictBody extends DefaultBody = DefaultBody,
   StatusCode extends number = number,

--- a/packages/zimic/src/types/json.ts
+++ b/packages/zimic/src/types/json.ts
@@ -1,3 +1,4 @@
+/** Value that can be represented in JSON. */
 export type JSONValue =
   | {
       [Key in never]: JSONValue;


### PR DESCRIPTION
### Documentation
- [#zimic] Added the API changes to `README.md`, including HTTP headers, HTTP search params and JSON values.

Closes #23.