### PR TITLE
feat: http request tracker clear (#100)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -725,6 +725,18 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
         expect(returnedNotifications).toEqual([]);
 
         expect(listRequests).toHaveLength(1);
+        expect(listTracker.requests()).toHaveLength(1);
+
+        listTracker.clear();
+
+        response = await listNotifications(notification.userId);
+        expect(response.status).toBe(200);
+
+        returnedNotifications = (await response.json()) as Notification[];
+        expect(returnedNotifications).toEqual([]);
+
+        expect(listRequests).toHaveLength(1);
+        expect(listTracker.requests()).toHaveLength(0);
       });
     });
   });

--- a/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
@@ -93,9 +93,13 @@ class HttpRequestTracker<
 
   bypass(): HttpRequestTracker<Schema, Method, Path, StatusCode> {
     this.createResponseDeclaration = undefined;
+    return this;
+  }
+
+  clear(): HttpRequestTracker<Schema, Method, Path, StatusCode> {
     this.restrictions = [];
     this.interceptedRequests = [];
-    return this;
+    return this.bypass();
   }
 
   matchesRequest(request: HttpInterceptorRequest<Default<Schema[Path][Method]>>): boolean {

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -101,13 +101,26 @@ export interface HttpRequestTracker<
   ) => HttpRequestTracker<Schema, Method, Path, StatusCode>;
 
   /**
-   * Clears any restrictions and declared responses and makes the tracker stop matching intercepted requests. The next
-   * tracker, created before this one, that matches the same method and path will be used if present. If not, the
-   * requests of the method and path will not be intercepted.
+   * Clears any declared responses, making the tracker stop matching intercepted requests. The next tracker, created
+   * before this one, that matches the same method and path will be used if present. If not, the requests of the method
+   * and path will not be intercepted.
+   *
+   * To make the tracker match requests again, register a new response with `tracker.respond()`.
    *
    * @see {@link https://github.com/diego-aquino/zimic#trackerbypass}
    */
   bypass: () => HttpRequestTracker<Schema, Method, Path, StatusCode>;
+
+  /**
+   * Clears any declared responses, restrictions, and intercepted requests, making the tracker stop matching intercepted
+   * requests. The next tracker, created before this one, that matches the same method and path will be used if present.
+   * If not, the requests of the method and path will not be intercepted.
+   *
+   * To make the tracker match requests again, register a new response with `tracker.respond()`.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#trackerclear}
+   */
+  clear: () => HttpRequestTracker<Schema, Method, Path, StatusCode>;
 
   /**
    * @returns The intercepted requests that matched this tracker, along with the responses returned to each of them.


### PR DESCRIPTION
### Features
- [#zimic] Created a new method `clear()` to clear all declared responses, restrictions and intercepted requests and responses from request trackers.
  - BREAKING CHANGE: [`tracker.bypass()`](https://github.com/diego-aquino/zimic#trackerbypass) no longer clears the intercepted requests and responses from the tracker.

Closes #100.