### PR TITLE
feat: request match by headers (#16)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -206,28 +206,36 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
       async function createUser(payload: UserCreationPayload) {
         const request = new Request('http://localhost:3000/users', {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json',
+          },
           body: JSON.stringify(payload),
         });
         return fetch(request);
       }
 
       it('should support creating users', async () => {
-        const creationTracker = authInterceptor.post('/users').respond((request) => {
-          expect(request.headers.get('content-type')).toBe('application/json');
+        const creationTracker = authInterceptor
+          .post('/users')
+          .with({
+            headers: { 'content-type': 'application/json' },
+          })
+          .respond((request) => {
+            expect(request.headers.get('content-type')).toBe('application/json');
 
-          const user: User = {
-            id: crypto.randomUUID(),
-            name: request.body.name,
-            email: request.body.email,
-          };
+            const user: User = {
+              id: crypto.randomUUID(),
+              name: request.body.name,
+              email: request.body.email,
+            };
 
-          return {
-            status: 201,
-            headers: { 'x-user-id': user.id },
-            body: user,
-          };
-        });
+            return {
+              status: 201,
+              headers: { 'x-user-id': user.id },
+              body: user,
+            };
+          });
 
         const response = await createUser(creationPayload);
         expect(response.status).toBe(201);

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -72,6 +72,56 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
       [keyof Schema & string, Defined<Schema[keyof Schema & string]>]
     >;
   }
+
+  equals<OtherSchema extends Schema>(otherHeaders: HttpHeaders<OtherSchema>): boolean {
+    for (const [key, value] of otherHeaders.entries()) {
+      const otherValue = super.get.call(this, key);
+      if (value !== otherValue) {
+        return false;
+      }
+    }
+
+    for (const otherKey of this.keys()) {
+      const hasKey = super.has.call(otherHeaders, otherKey);
+      if (!hasKey) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  contains<OtherSchema extends Schema>(otherHeaders: HttpHeaders<OtherSchema>): boolean {
+    for (const [key, value] of otherHeaders.entries()) {
+      const otherValue = super.get.call(this, key);
+
+      if (otherValue === null) {
+        return false;
+      }
+
+      const valueItems = this.splitHeaderValues(value);
+      const otherValueItems = this.splitHeaderValues(otherValue);
+
+      if (otherValueItems.length < valueItems.length) {
+        return false;
+      }
+
+      for (const valueItem of valueItems) {
+        if (!otherValueItems.includes(valueItem)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private splitHeaderValues(value: string) {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
 }
 
 export default HttpHeaders;

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -49,11 +49,7 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
   }
 
   forEach<This extends HttpHeaders<Schema>>(
-    callback: <Key extends keyof Schema & string>(
-      value: Defined<Schema[Key]>,
-      key: Key,
-      parent: HttpHeaders<Schema>,
-    ) => void,
+    callback: <Key extends keyof Schema & string>(value: Defined<Schema[Key]>, key: Key, parent: Headers) => void,
     thisArg?: This,
   ): void {
     super.forEach(callback as (value: string, key: string, parent: Headers) => void, thisArg);

--- a/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
@@ -316,4 +316,122 @@ describe('HttpHeaders', () => {
       ]),
     );
   });
+
+  it('should support checking equality with other headers', () => {
+    const headers = new HttpHeaders<{
+      accept?: string;
+      'content-type'?: `application/${string}`;
+      'keep-alive'?: string;
+    }>({
+      accept: '*/*',
+      'content-type': 'application/json',
+    });
+
+    const otherHeaders = new HttpHeaders<{
+      accept?: string;
+      'content-type'?: `application/${string}`;
+    }>({
+      accept: '*/*',
+      'content-type': 'application/json',
+    });
+
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    headers.append('accept', 'application/xml');
+    expect(headers.equals(otherHeaders)).toBe(false);
+    headers.set('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    otherHeaders.delete('accept');
+    expect(headers.equals(otherHeaders)).toBe(false);
+    otherHeaders.append('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    headers.append('accept', 'application/json');
+    otherHeaders.append('accept', 'application/json');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    otherHeaders.append('accept', 'image/png');
+    expect(headers.equals(otherHeaders)).toBe(false);
+    otherHeaders.set('accept', '*/*, application/json');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    headers.set('accept', '*/*');
+    otherHeaders.set('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    otherHeaders.set('content-type', 'application/xml');
+    expect(headers.equals(otherHeaders)).toBe(false);
+    otherHeaders.set('content-type', 'application/json');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    headers.delete('accept');
+    expect(headers.equals(otherHeaders)).toBe(false);
+    headers.set('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    headers.set('keep-alive', 'timeout=5');
+    expect(headers.equals(otherHeaders)).toBe(false);
+    headers.delete('keep-alive');
+    expect(headers.equals(otherHeaders)).toBe(true);
+  });
+
+  it('should support checking containment with other headers', () => {
+    const headers = new HttpHeaders<{
+      accept?: string;
+      'content-type'?: `${string}/${string}`;
+      'keep-alive'?: string;
+    }>({
+      accept: '*/*',
+      'content-type': 'application/json',
+    });
+
+    const otherHeaders = new HttpHeaders<{
+      accept?: string;
+      'content-type'?: `${string}/${string}`;
+    }>({
+      accept: '*/*',
+      'content-type': 'application/json',
+    });
+
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    headers.append('accept', 'application/xml');
+    expect(headers.contains(otherHeaders)).toBe(true);
+    headers.set('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    otherHeaders.delete('accept');
+    expect(headers.contains(otherHeaders)).toBe(true);
+    otherHeaders.append('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    headers.append('accept', 'application/json');
+    otherHeaders.append('accept', 'application/json');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    otherHeaders.append('accept', 'image/png');
+    expect(headers.contains(otherHeaders)).toBe(false);
+    otherHeaders.set('accept', '*/*, application/json');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    headers.set('accept', '*/*');
+    otherHeaders.set('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    otherHeaders.set('content-type', 'application/xml');
+    expect(headers.contains(otherHeaders)).toBe(false);
+    otherHeaders.set('content-type', 'application/json');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    headers.delete('accept');
+    expect(headers.contains(otherHeaders)).toBe(false);
+    headers.set('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    headers.set('keep-alive', 'timeout=5');
+    expect(headers.contains(otherHeaders)).toBe(true);
+    headers.delete('keep-alive');
+    expect(headers.contains(otherHeaders)).toBe(true);
+  });
 });

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -103,8 +103,8 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = never> extends UR
   }
 
   contains<OtherSchema extends Schema>(otherParams: HttpSearchParams<OtherSchema>): boolean {
-    for (const [key, value] of this.entries()) {
-      if (!super.has.call(otherParams, key, value)) {
+    for (const [key, value] of otherParams.entries()) {
+      if (!super.has.call(this, key, value)) {
         return false;
       }
     }

--- a/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -396,6 +396,7 @@ describe('HttpSearchParams', () => {
     const searchParams = new HttpSearchParams<{
       names?: string[];
       page?: `${number}`;
+      orderBy?: string;
     }>({
       names: ['User1', 'User2'],
       page: '1',
@@ -404,7 +405,6 @@ describe('HttpSearchParams', () => {
     const otherSearchParams = new HttpSearchParams<{
       names?: string[];
       page?: `${number}`;
-      orderBy?: string;
     }>({
       names: ['User1', 'User2'],
       page: '1',
@@ -412,29 +412,29 @@ describe('HttpSearchParams', () => {
 
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
-    otherSearchParams.append('names', 'User3');
+    searchParams.append('names', 'User3');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
-    otherSearchParams.delete('names', 'User3');
+    searchParams.delete('names', 'User3');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
-    otherSearchParams.set('page', '2');
+    searchParams.set('page', '2');
     expect(searchParams.contains(otherSearchParams)).toBe(false);
-    otherSearchParams.set('page', '1');
+    searchParams.set('page', '1');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
-    otherSearchParams.delete('names', 'User2');
+    searchParams.delete('names', 'User2');
     expect(searchParams.contains(otherSearchParams)).toBe(false);
-    otherSearchParams.append('names', 'User2');
+    searchParams.append('names', 'User2');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
-    otherSearchParams.delete('page');
+    searchParams.delete('page');
     expect(searchParams.contains(otherSearchParams)).toBe(false);
-    otherSearchParams.set('page', '1');
+    searchParams.set('page', '1');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
-    otherSearchParams.set('orderBy', 'asc');
+    searchParams.set('orderBy', 'asc');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
-    otherSearchParams.delete('orderBy', 'asc');
+    searchParams.delete('orderBy', 'asc');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
   });
 });

--- a/packages/zimic/src/http/types/requests.ts
+++ b/packages/zimic/src/http/types/requests.ts
@@ -2,9 +2,18 @@ import { JSONValue } from '@/types/json';
 
 import HttpHeaders from '../headers/HttpHeaders';
 import { HttpHeadersSchema } from '../headers/types';
+import HttpSearchParams from '../searchParams/HttpSearchParams';
+import { HttpSearchParamsSchema } from '../searchParams/types';
 
 /** The default body type (JSON) for HTTP requests and responses. */
 export type DefaultBody = JSONValue;
+
+export type StrictHeaders<Schema extends HttpHeadersSchema> = Pick<HttpHeaders<Schema>, keyof Headers>;
+
+export type StrictURLSearchParams<Schema extends HttpSearchParamsSchema> = Pick<
+  HttpSearchParams<Schema>,
+  keyof URLSearchParams
+>;
 
 /**
  * An HTTP request with a strictly-typed JSON body. Fully compatible with the built-in
@@ -14,7 +23,7 @@ export interface HttpRequest<
   StrictBody extends DefaultBody = DefaultBody,
   StrictHeadersSchema extends HttpHeadersSchema = HttpHeadersSchema,
 > extends Request {
-  headers: HttpHeaders<StrictHeadersSchema>;
+  headers: StrictHeaders<StrictHeadersSchema>;
   json: () => Promise<StrictBody>;
 }
 
@@ -28,6 +37,6 @@ export interface HttpResponse<
   StrictHeadersSchema extends HttpHeadersSchema = HttpHeadersSchema,
 > extends Response {
   status: StatusCode;
-  headers: HttpHeaders<StrictHeadersSchema>;
+  headers: StrictHeaders<StrictHeadersSchema>;
   json: () => Promise<StrictBody>;
 }

--- a/packages/zimic/src/index.ts
+++ b/packages/zimic/src/index.ts
@@ -11,6 +11,12 @@ export type {
   HttpSearchParamsSchemaTuple,
 } from './http/searchParams/types';
 
-export type { DefaultBody, HttpRequest, HttpResponse } from './http/types/requests';
+export type {
+  DefaultBody,
+  HttpRequest,
+  StrictHeaders,
+  StrictURLSearchParams,
+  HttpResponse,
+} from './http/types/requests';
 
 export { HttpSearchParams, HttpHeaders };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -173,6 +173,79 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
     });
   });
 
+  it('should support intercepting GET requests having headers restrictions', async () => {
+    type UserListHeaders = HttpInterceptorSchema.Headers<{
+      'content-type'?: string;
+      accept?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        GET: {
+          request: {
+            headers: UserListHeaders;
+          };
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const listTracker = interceptor
+        .get('/users')
+        .with({
+          headers: { 'content-type': 'application/json' },
+        })
+        .with((request) => {
+          expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserListHeaders>>();
+          expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+          return request.headers.get('accept')?.includes('application/json') ?? false;
+        })
+        .respond((request) => {
+          expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserListHeaders>>();
+          expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+          return {
+            status: 200,
+            body: users,
+          };
+        });
+      expect(listTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const listRequests = listTracker.requests();
+      expect(listRequests).toHaveLength(0);
+
+      const headers = new HttpHeaders<UserListHeaders>({
+        'content-type': 'application/json',
+        accept: 'application/json',
+      });
+
+      let listResponse = await fetch(`${baseURL}/users`, { method: 'GET', headers });
+      expect(listResponse.status).toBe(200);
+      expect(listRequests).toHaveLength(1);
+
+      headers.append('accept', 'application/xml');
+
+      listResponse = await fetch(`${baseURL}/users`, { method: 'GET', headers });
+      expect(listResponse.status).toBe(200);
+      expect(listRequests).toHaveLength(2);
+
+      headers.delete('accept');
+
+      let listResponsePromise = fetch(`${baseURL}/users`, { method: 'GET', headers });
+      await expect(listResponsePromise).rejects.toThrowError();
+      expect(listRequests).toHaveLength(2);
+
+      headers.set('accept', 'application/json');
+      headers.set('content-type', 'text/plain');
+
+      listResponsePromise = fetch(`${baseURL}/users`, { method: 'GET', headers });
+      await expect(listResponsePromise).rejects.toThrowError();
+      expect(listRequests).toHaveLength(2);
+    });
+  });
+
   it('should support intercepting GET requests having search params restrictions', async () => {
     type UserListSearchParams = HttpInterceptorSchema.SearchParams<{
       name?: string;
@@ -232,12 +305,14 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
 
       let listResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'GET' });
       await expect(listResponsePromise).rejects.toThrowError();
+      expect(listRequests).toHaveLength(1);
 
       searchParams.append('orderBy', 'name');
       searchParams.set('name', 'User 2');
 
       listResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'GET' });
       await expect(listResponsePromise).rejects.toThrowError();
+      expect(listRequests).toHaveLength(1);
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -173,6 +173,79 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     });
   });
 
+  it('should support intercepting PATCH requests having headers restrictions', async () => {
+    type UserUpdateHeaders = HttpInterceptorSchema.Headers<{
+      'content-type'?: string;
+      accept?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        PATCH: {
+          request: {
+            headers: UserUpdateHeaders;
+          };
+          response: {
+            200: { body: User };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const updateTracker = interceptor
+        .patch('/users')
+        .with({
+          headers: { 'content-type': 'application/json' },
+        })
+        .with((request) => {
+          expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateHeaders>>();
+          expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+          return request.headers.get('accept')?.includes('application/json') ?? false;
+        })
+        .respond((request) => {
+          expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateHeaders>>();
+          expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+          return {
+            status: 200,
+            body: users[0],
+          };
+        });
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const updateRequests = updateTracker.requests();
+      expect(updateRequests).toHaveLength(0);
+
+      const headers = new HttpHeaders<UserUpdateHeaders>({
+        'content-type': 'application/json',
+        accept: 'application/json',
+      });
+
+      let updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      expect(updateResponse.status).toBe(200);
+      expect(updateRequests).toHaveLength(1);
+
+      headers.append('accept', 'application/xml');
+
+      updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      expect(updateResponse.status).toBe(200);
+      expect(updateRequests).toHaveLength(2);
+
+      headers.delete('accept');
+
+      let updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      await expect(updateResponsePromise).rejects.toThrowError();
+      expect(updateRequests).toHaveLength(2);
+
+      headers.set('accept', 'application/json');
+      headers.set('content-type', 'text/plain');
+
+      updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      await expect(updateResponsePromise).rejects.toThrowError();
+      expect(updateRequests).toHaveLength(2);
+    });
+  });
+
   it('should support intercepting PATCH requests having search params restrictions', async () => {
     type UserUpdateSearchParams = HttpInterceptorSchema.SearchParams<{
       tag?: string;
@@ -221,6 +294,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
       const updateResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
       await expect(updateResponsePromise).rejects.toThrowError();
+      expect(updateRequests).toHaveLength(1);
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -176,6 +176,79 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
     });
   });
 
+  it('should support intercepting POST requests having headers restrictions', async () => {
+    type UserCreationHeaders = HttpInterceptorSchema.Headers<{
+      'content-type'?: string;
+      accept?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        POST: {
+          request: {
+            headers: UserCreationHeaders;
+          };
+          response: {
+            200: { body: User };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const creationTracker = interceptor
+        .post('/users')
+        .with({
+          headers: { 'content-type': 'application/json' },
+        })
+        .with((request) => {
+          expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserCreationHeaders>>();
+          expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+          return request.headers.get('accept')?.includes('application/json') ?? false;
+        })
+        .respond((request) => {
+          expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserCreationHeaders>>();
+          expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+          return {
+            status: 200,
+            body: users[0],
+          };
+        });
+      expect(creationTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const creationRequests = creationTracker.requests();
+      expect(creationRequests).toHaveLength(0);
+
+      const headers = new HttpHeaders<UserCreationHeaders>({
+        'content-type': 'application/json',
+        accept: 'application/json',
+      });
+
+      let creationResponse = await fetch(`${baseURL}/users`, { method: 'POST', headers });
+      expect(creationResponse.status).toBe(200);
+      expect(creationRequests).toHaveLength(1);
+
+      headers.append('accept', 'application/xml');
+
+      creationResponse = await fetch(`${baseURL}/users`, { method: 'POST', headers });
+      expect(creationResponse.status).toBe(200);
+      expect(creationRequests).toHaveLength(2);
+
+      headers.delete('accept');
+
+      let creationResponsePromise = fetch(`${baseURL}/users`, { method: 'POST', headers });
+      await expect(creationResponsePromise).rejects.toThrowError();
+      expect(creationRequests).toHaveLength(2);
+
+      headers.set('accept', 'application/json');
+      headers.set('content-type', 'text/plain');
+
+      creationResponsePromise = fetch(`${baseURL}/users`, { method: 'POST', headers });
+      await expect(creationResponsePromise).rejects.toThrowError();
+      expect(creationRequests).toHaveLength(2);
+    });
+  });
+
   it('should support intercepting POST requests having search params restrictions', async () => {
     type UserCreationSearchParams = HttpInterceptorSchema.SearchParams<{
       tag?: string;
@@ -224,6 +297,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
 
       const creationResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'POST' });
       await expect(creationResponsePromise).rejects.toThrowError();
+      expect(creationRequests).toHaveLength(1);
     });
   });
 

--- a/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
@@ -1,3 +1,4 @@
+import HttpHeaders from '@/http/headers/HttpHeaders';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { Default } from '@/types/utils';
 
@@ -112,20 +113,34 @@ class HttpRequestTracker<
       if (this.isComputedRequestRestriction(restriction)) {
         return restriction(request);
       }
-      return this.matchesRequestSearchParamsRestrictions(request, restriction);
+      return (
+        this.matchesRequestHeadersRestrictions(request, restriction) &&
+        this.matchesRequestSearchParamsRestrictions(request, restriction)
+      );
     });
+  }
+
+  private matchesRequestHeadersRestrictions(
+    request: HttpInterceptorRequest<Default<Schema[Path][Method]>>,
+    restriction: HttpRequestTrackerStaticRestriction<Schema, Path, Method>,
+  ) {
+    if (!restriction.headers) {
+      return true;
+    }
+
+    const restrictedHeaders = new HttpHeaders(restriction.headers);
+    return restriction.exact ? request.headers.equals(restrictedHeaders) : request.headers.contains(restrictedHeaders);
   }
 
   private matchesRequestSearchParamsRestrictions(
     request: HttpInterceptorRequest<Default<Schema[Path][Method]>>,
     restriction: HttpRequestTrackerStaticRestriction<Schema, Path, Method>,
-  ): unknown {
+  ) {
     if (!restriction.searchParams) {
       return true;
     }
 
     const restrictedSearchParams = new HttpSearchParams(restriction.searchParams);
-
     return restriction.exact
       ? request.searchParams.equals(restrictedSearchParams)
       : request.searchParams.contains(restrictedSearchParams);

--- a/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/HttpRequestTracker.ts
@@ -127,8 +127,8 @@ class HttpRequestTracker<
     const restrictedSearchParams = new HttpSearchParams(restriction.searchParams);
 
     return restriction.exact
-      ? restrictedSearchParams.equals(request.searchParams)
-      : restrictedSearchParams.contains(request.searchParams);
+      ? request.searchParams.equals(restrictedSearchParams)
+      : request.searchParams.contains(restrictedSearchParams);
   }
 
   private isComputedRequestRestriction(

--- a/packages/zimic/src/interceptor/http/requestTracker/__tests__/shared/requestTrackerTests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/__tests__/shared/requestTrackerTests.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf, expect, vi, it, beforeAll, afterAll, describe } from 'vitest';
 
+import HttpHeaders from '@/http/headers/HttpHeaders';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HttpRequest, HttpResponse } from '@/http/types/requests';
 import { createHttpInterceptor } from '@/interceptor/http/interceptor/factory';
@@ -24,6 +25,11 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
   describe('Shared', () => {
     const baseURL = 'http://localhost:3000';
 
+    type HeadersSchema = HttpInterceptorSchema.Headers<{
+      accept?: string;
+      'content-type'?: string;
+    }>;
+
     type SearchParamsSchema = HttpInterceptorSchema.SearchParams<{
       name?: string;
       other?: string;
@@ -31,6 +37,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
 
     type MethodSchema = HttpInterceptorSchema.Method<{
       request: {
+        headers: HeadersSchema;
         searchParams: SearchParamsSchema;
         body: { success?: undefined };
       };
@@ -345,49 +352,86 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
       }
     });
 
-    describe('Match by search params', () => {
-      it.each([{ exact: true }])(
-        'should match only specific requests if contains a declared response, a static search param restriction, and exact: $exact',
-        async ({ exact }) => {
+    describe('Restrictions', () => {
+      describe('By search params', () => {
+        it.each([{ exact: true }])(
+          'should match only specific requests if contains a declared response, a static search param restriction, and exact: $exact',
+          async ({ exact }) => {
+            const name = 'User';
+
+            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+              .with({
+                searchParams: { name },
+                exact,
+              })
+              .respond({
+                status: 200,
+                body: { success: true },
+              });
+
+            for (const matchingSearchParams of [new HttpSearchParams<SearchParamsSchema>({ name })]) {
+              const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`);
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+            }
+
+            for (const mismatchingSearchParams of [
+              new HttpSearchParams<SearchParamsSchema>({ name, other: 'param' }),
+              new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
+              new HttpSearchParams<SearchParamsSchema>({}),
+            ]) {
+              const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`);
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+            }
+          },
+        );
+
+        it.each([{ exact: false }, { exact: undefined }])(
+          'should match only specific requests if contains a declared response, a static search param restriction, and exact: $exact',
+          async ({ exact }) => {
+            const name = 'User';
+
+            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+              .with({
+                searchParams: { name },
+                exact,
+              })
+              .respond({
+                status: 200,
+                body: { success: true },
+              });
+
+            for (const matchingSearchParams of [
+              new HttpSearchParams<SearchParamsSchema>({ name }),
+              new HttpSearchParams<SearchParamsSchema>({ name, other: 'param' }),
+            ]) {
+              const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`);
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+            }
+
+            for (const mismatchingSearchParams of [
+              new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
+              new HttpSearchParams<SearchParamsSchema>({}),
+            ]) {
+              const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`);
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+            }
+          },
+        );
+
+        it('should match only specific requests if contains a declared response and a computed search params restriction', async () => {
           const name = 'User';
 
           const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
-            .with({
-              searchParams: { name },
-              exact,
-            })
-            .respond({
-              status: 200,
-              body: { success: true },
-            });
+            .with((request) => {
+              expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<SearchParamsSchema>>();
+              expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
-          for (const matchingSearchParams of [new HttpSearchParams<SearchParamsSchema>({ name })]) {
-            const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`);
-            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
-            expect(tracker.matchesRequest(parsedRequest)).toBe(true);
-          }
-
-          for (const mismatchingSearchParams of [
-            new HttpSearchParams<SearchParamsSchema>({ name, other: 'param' }),
-            new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
-            new HttpSearchParams<SearchParamsSchema>({}),
-          ]) {
-            const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`);
-            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
-            expect(tracker.matchesRequest(parsedRequest)).toBe(false);
-          }
-        },
-      );
-
-      it.each([{ exact: false }, { exact: undefined }])(
-        'should match only specific requests if contains a declared response, a static search param restriction, and exact: $exact',
-        async ({ exact }) => {
-          const name = 'User';
-
-          const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
-            .with({
-              searchParams: { name },
-              exact,
+              const nameParam = request.searchParams.get('name');
+              return nameParam?.startsWith(name) ?? false;
             })
             .respond({
               status: 200,
@@ -397,6 +441,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
           for (const matchingSearchParams of [
             new HttpSearchParams<SearchParamsSchema>({ name }),
             new HttpSearchParams<SearchParamsSchema>({ name, other: 'param' }),
+            new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
           ]) {
             const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`);
             const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
@@ -404,91 +449,209 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
           }
 
           for (const mismatchingSearchParams of [
-            new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
+            new HttpSearchParams<SearchParamsSchema>({ name: `Other ${name}` }),
             new HttpSearchParams<SearchParamsSchema>({}),
           ]) {
             const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`);
             const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
             expect(tracker.matchesRequest(parsedRequest)).toBe(false);
           }
-        },
-      );
+        });
+      });
 
-      it('should match only specific requests if contains a declared response and a computed search params restriction', async () => {
-        const name = 'User';
+      describe('By headers', () => {
+        it.each([{ exact: true }])(
+          'should match only specific requests if contains a declared response, a static header restriction, and exact: $exact',
+          async ({ exact }) => {
+            const contentType = 'application/json';
 
-        const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
-          .with((request) => {
-            expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<SearchParamsSchema>>();
-            expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
+            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+              .with({
+                headers: { 'content-type': contentType },
+                exact,
+              })
+              .respond({
+                status: 200,
+                body: { success: true },
+              });
 
-            const nameParam = request.searchParams.get('name');
-            return nameParam?.startsWith(name) ?? false;
-          })
-          .respond({
-            status: 200,
-            body: { success: true },
-          });
+            for (const matchingHeaders of [new HttpHeaders<HeadersSchema>({ 'content-type': contentType })]) {
+              const matchingRequest = new Request(baseURL, { headers: matchingHeaders });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+            }
 
-        for (const matchingSearchParams of [
-          new HttpSearchParams<SearchParamsSchema>({ name }),
-          new HttpSearchParams<SearchParamsSchema>({ name, other: 'param' }),
-          new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
-        ]) {
-          const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`);
-          const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
-          expect(tracker.matchesRequest(parsedRequest)).toBe(true);
-        }
+            for (const mismatchingHeaders of [
+              new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: '*/*' }),
+              new HttpHeaders<HeadersSchema>({ 'content-type': `${contentType}/other` }),
+              new HttpHeaders<HeadersSchema>({}),
+            ]) {
+              const request = new Request(baseURL, { headers: mismatchingHeaders });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+            }
+          },
+        );
 
-        for (const mismatchingSearchParams of [
-          new HttpSearchParams<SearchParamsSchema>({ name: `Other ${name}` }),
-          new HttpSearchParams<SearchParamsSchema>({}),
-        ]) {
-          const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`);
-          const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
-          expect(tracker.matchesRequest(parsedRequest)).toBe(false);
-        }
+        it.each([{ exact: false }, { exact: undefined }])(
+          'should match only specific requests if contains a declared response, a static header restriction, and exact: $exact',
+          async ({ exact }) => {
+            const contentType = 'application/json';
+
+            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+              .with({
+                headers: { 'content-type': contentType },
+                exact,
+              })
+              .respond({
+                status: 200,
+                body: { success: true },
+              });
+
+            for (const matchingHeaders of [
+              new HttpHeaders<HeadersSchema>({ 'content-type': contentType }),
+              new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: '*/*' }),
+            ]) {
+              const matchingRequest = new Request(baseURL, { headers: matchingHeaders });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+            }
+
+            for (const mismatchingHeaders of [
+              new HttpHeaders<HeadersSchema>({ 'content-type': `${contentType}/other` }),
+              new HttpHeaders<HeadersSchema>({}),
+            ]) {
+              const request = new Request(baseURL, { headers: mismatchingHeaders });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+            }
+          },
+        );
+
+        it('should match only specific requests if contains a declared response and a computed header restriction', async () => {
+          const contentType = 'application/json';
+
+          const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+            .with((request) => {
+              expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<HeadersSchema>>();
+              expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+              const nameParam = request.headers.get('content-type');
+              return nameParam?.startsWith(contentType) ?? false;
+            })
+            .respond({
+              status: 200,
+              body: { success: true },
+            });
+
+          for (const matchingHeaders of [
+            new HttpHeaders<HeadersSchema>({ 'content-type': contentType }),
+            new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: '*/*' }),
+            new HttpHeaders<HeadersSchema>({ 'content-type': `${contentType}/other` }),
+          ]) {
+            const matchingRequest = new Request(baseURL, { headers: matchingHeaders });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+          }
+
+          for (const mismatchingHeaders of [
+            new HttpHeaders<HeadersSchema>({ 'content-type': `other/${contentType}` }),
+            new HttpHeaders<HeadersSchema>({}),
+          ]) {
+            const request = new Request(baseURL, { headers: mismatchingHeaders });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+          }
+        });
       });
 
       it('should match only specific requests if contains a declared response and multiple restrictions', async () => {
         const name = 'User';
+        const contentType = 'application/json';
 
         const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
           .with({
+            headers: { 'content-type': contentType },
             searchParams: { name },
           })
           .with((request) => {
+            expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<HeadersSchema>>();
+            expect(request.headers).toBeInstanceOf(HttpHeaders);
+
             expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<SearchParamsSchema>>();
             expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
-            return request.searchParams.get('other')?.includes('param') ?? false;
+            const matchesHeaders = request.headers.get('accept')?.includes('*/*') ?? false;
+            const matchesSearchParams = request.searchParams.get('other')?.includes('param') ?? false;
+
+            return matchesHeaders && matchesSearchParams;
           })
           .respond({
             status: 200,
             body: { success: true },
           });
 
-        for (const matchingSearchParams of [
+        const matchingHeadersSamples = [
+          new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: '*/*' }),
+          new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: 'application/json, */*' }),
+          new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: '*/*, application/json' }),
+        ];
+
+        const mismatchingHeadersSamples = [
+          new HttpHeaders<HeadersSchema>({ 'content-type': contentType, accept: 'application/json' }),
+          new HttpHeaders<HeadersSchema>({ 'content-type': contentType }),
+          new HttpHeaders<HeadersSchema>({}),
+        ];
+
+        const matchingSearchParamsSamples = [
           new HttpSearchParams<SearchParamsSchema>({ name, other: 'param' }),
           new HttpSearchParams<SearchParamsSchema>({ name, other: 'prefix-param' }),
           new HttpSearchParams<SearchParamsSchema>({ name, other: 'param-suffix' }),
           new HttpSearchParams<SearchParamsSchema>({ name, other: 'prefix-param-suffix' }),
-        ]) {
-          const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`);
-          const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
-          expect(tracker.matchesRequest(parsedRequest)).toBe(true);
-        }
+        ];
 
-        for (const mismatchingSearchParams of [
+        const mismatchingSearchParamsSamples = [
           new HttpSearchParams<SearchParamsSchema>({ name }),
           new HttpSearchParams<SearchParamsSchema>({ name: `Other ${name}` }),
           new HttpSearchParams<SearchParamsSchema>({ other: 'param' }),
           new HttpSearchParams<SearchParamsSchema>({ other: `Other param` }),
           new HttpSearchParams<SearchParamsSchema>({}),
-        ]) {
-          const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`);
-          const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
-          expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+        ];
+
+        for (const matchingHeaders of matchingHeadersSamples) {
+          for (const matchingSearchParams of matchingSearchParamsSamples) {
+            const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`, {
+              headers: matchingHeaders,
+            });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+          }
+
+          for (const mismatchingSearchParams of mismatchingSearchParamsSamples) {
+            const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`, {
+              headers: matchingHeaders,
+            });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+          }
+        }
+
+        for (const mismatchingHeaders of mismatchingHeadersSamples) {
+          for (const matchingSearchParams of matchingSearchParamsSamples) {
+            const matchingRequest = new Request(`${baseURL}?${matchingSearchParams.toString()}`, {
+              headers: mismatchingHeaders,
+            });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+          }
+
+          for (const mismatchingSearchParams of mismatchingSearchParamsSamples) {
+            const request = new Request(`${baseURL}?${mismatchingSearchParams.toString()}`, {
+              headers: mismatchingHeaders,
+            });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+          }
         }
       });
     });

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -1,3 +1,4 @@
+import HttpHeaders from '@/http/headers/HttpHeaders';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { Default } from '@/types/utils';
 
@@ -8,6 +9,7 @@ import {
   HttpInterceptorSchemaPath,
 } from '../../interceptor/types/schema';
 import {
+  HttpHeadersRequestSchema,
   HttpInterceptorRequest,
   HttpRequestTrackerResponseDeclaration,
   HttpRequestTrackerResponseDeclarationFactory,
@@ -23,11 +25,20 @@ export type HttpRequestTrackerSearchParamsStaticRestriction<
   | HttpSearchParamsRequestSchema<Default<Schema[Path][Method]>>
   | HttpSearchParams<HttpSearchParamsRequestSchema<Default<Schema[Path][Method]>>>;
 
+export type HttpRequestTrackerHeadersStaticRestriction<
+  Schema extends HttpInterceptorSchema,
+  Path extends HttpInterceptorSchemaPath<Schema, Method>,
+  Method extends HttpInterceptorSchemaMethod<Schema>,
+> =
+  | HttpHeadersRequestSchema<Default<Schema[Path][Method]>>
+  | HttpHeaders<HttpHeadersRequestSchema<Default<Schema[Path][Method]>>>;
+
 export interface HttpRequestTrackerStaticRestriction<
   Schema extends HttpInterceptorSchema,
   Path extends HttpInterceptorSchemaPath<Schema, Method>,
   Method extends HttpInterceptorSchemaMethod<Schema>,
 > {
+  headers?: HttpRequestTrackerHeadersStaticRestriction<Schema, Path, Method>;
   searchParams?: HttpRequestTrackerSearchParamsStaticRestriction<Schema, Path, Method>;
   exact?: boolean;
 }

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -1,3 +1,4 @@
+import HttpHeaders from '@/http/headers/HttpHeaders';
 import { HttpHeadersInit } from '@/http/headers/types';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HttpRequest, HttpResponse } from '@/http/types/requests';
@@ -37,13 +38,8 @@ export type HttpSearchParamsRequestSchema<MethodSchema extends HttpInterceptorMe
 >;
 
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
-  extends Omit<
-    HttpRequest<
-      Default<Default<MethodSchema['request'], { body: null }>['body'], null>,
-      Default<Default<MethodSchema['request'], { headers: never }>['headers']>
-    >,
-    keyof Body
-  > {
+  extends Omit<HttpRequest, keyof Body | 'headers'> {
+  headers: HttpHeaders<Default<Default<MethodSchema['request'], { headers: never }>['headers']>>;
   searchParams: HttpSearchParams<HttpSearchParamsRequestSchema<MethodSchema>>;
   body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
   raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;
@@ -52,14 +48,8 @@ export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMeth
 export interface HttpInterceptorResponse<
   MethodSchema extends HttpInterceptorMethodSchema,
   StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<MethodSchema['response']>>,
-> extends Omit<
-    HttpResponse<
-      Default<Default<MethodSchema['response']>[StatusCode]['body'], null>,
-      StatusCode,
-      Default<Default<MethodSchema['response']>[StatusCode]['headers']>
-    >,
-    keyof Body
-  > {
+> extends Omit<HttpResponse, keyof Body | 'headers'> {
+  headers: HttpHeaders<Default<Default<MethodSchema['response']>[StatusCode]['headers']>>;
   status: StatusCode;
   body: Default<Default<MethodSchema['response']>[StatusCode]['body'], null>;
   raw: HttpResponse<Default<Default<MethodSchema['response']>[StatusCode]['body'], null>, StatusCode>;

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -33,13 +33,17 @@ export type HttpRequestTrackerResponseDeclarationFactory<
   request: Omit<HttpInterceptorRequest<MethodSchema>, 'response'>,
 ) => PossiblePromise<HttpRequestTrackerResponseDeclaration<MethodSchema, StatusCode>>;
 
+export type HttpHeadersRequestSchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
+  Default<MethodSchema['request'], { headers: never }>['headers']
+>;
+
 export type HttpSearchParamsRequestSchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
   Default<MethodSchema['request'], { searchParams: never }>['searchParams']
 >;
 
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body | 'headers'> {
-  headers: HttpHeaders<Default<Default<MethodSchema['request'], { headers: never }>['headers']>>;
+  headers: HttpHeaders<HttpHeadersRequestSchema<MethodSchema>>;
   searchParams: HttpSearchParams<HttpSearchParamsRequestSchema<MethodSchema>>;
   body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
   raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;


### PR DESCRIPTION
### Features
- [#zimic] Added support to restrict request trackers by HTTP headers.
- [#zimic] Added support to compare equality and containment of HTTP headers.

### Fixes
- [#zimic] Fixed the semantics of search param comparisons. Now `param1.contains(param2)` returns `true` only if all key-value pairs of `param2` are present in `param1`, regardless of `param1` having more key-pairs than `param2`. The previous behavior was that `param1.contains(param2)` would return `true` only if all key-value pairs of `param1` were present in `param2`, which is not correct because the semantics are reversed.

```ts
const creationTracker = authInterceptor
  .post('/users')
  .with({
    headers: { 'content-type': 'application/json' },
  })
  .respond((request) => {
    const user: User = {
      id: crypto.randomUUID(),
      name: request.body.name,
      email: request.body.email,
    };

    return {
      status: 201,
      body: user,
    };
  });

const response = await createUser(creationPayload);
expect(response.status).toBe(201);
```

Closes #86.