### PR TITLE
feat: request match by body (#12)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -86,7 +86,18 @@ describe('Exports', () => {
     expectTypeOf<HttpInterceptorResponseSchemaStatusCode<never>>().not.toBeAny();
     expectTypeOf<HttpInterceptorMethodSchema>().not.toBeAny();
     expectTypeOf<HttpInterceptorPathSchema>().not.toBeAny();
+
     expectTypeOf<HttpInterceptorSchema>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Root<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Path<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Method<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Request<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Response<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.ResponseByStatusCode<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Headers<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.SearchParams<never>>().not.toBeAny();
+    expectTypeOf<HttpInterceptorSchema.Body<never>>().not.toBeAny();
+
     expectTypeOf<HttpInterceptorSchemaMethod<never>>().not.toBeAny();
     expectTypeOf<LiteralHttpInterceptorSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<NonLiteralHttpInterceptorSchemaPath<never, never>>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -220,6 +220,7 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
           .post('/users')
           .with({
             headers: { 'content-type': 'application/json' },
+            body: creationPayload,
           })
           .respond((request) => {
             expect(request.headers.get('content-type')).toBe('application/json');
@@ -280,10 +281,15 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
           code: 'validation_error',
           message: 'Invalid payload',
         };
-        const creationTracker = authInterceptor.post('/users').respond({
-          status: 400,
-          body: validationError,
-        });
+        const creationTracker = authInterceptor
+          .post('/users')
+          .with({
+            body: invalidPayload,
+          })
+          .respond({
+            status: 400,
+            body: validationError,
+          });
 
         const response = await createUser(invalidPayload);
         expect(response.status).toBe(400);
@@ -318,10 +324,15 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
           code: 'conflict',
           message: 'User already exists',
         };
-        const creationTracker = authInterceptor.post('/users').respond({
-          status: 409,
-          body: conflictError,
-        });
+        const creationTracker = authInterceptor
+          .post('/users')
+          .with({
+            body: conflictingPayload,
+          })
+          .respond({
+            status: 409,
+            body: conflictError,
+          });
 
         const response = await createUser(conflictingPayload);
         expect(response.status).toBe(409);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/interceptorTests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/interceptorTests.ts
@@ -27,7 +27,7 @@ export function declareSharedHttpInterceptorTests(options: SharedHttpInterceptor
   });
 
   describe('Methods', () => {
-    const methodTestFactories: Record<HttpInterceptorMethod, () => void> = {
+    const methodTestFactories: Record<HttpInterceptorMethod, () => Promise<void> | void> = {
       GET: declareGetHttpInterceptorTests.bind(null, options),
       POST: declarePostHttpInterceptorTests.bind(null, options),
       PUT: declarePutHttpInterceptorTests.bind(null, options),
@@ -38,8 +38,8 @@ export function declareSharedHttpInterceptorTests(options: SharedHttpInterceptor
     };
 
     for (const [method, methodTestFactory] of Object.entries(methodTestFactories)) {
-      describe(method, () => {
-        methodTestFactory();
+      describe(method, async () => {
+        await methodTestFactory();
       });
     }
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -5,13 +5,16 @@ import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import { getCrypto } from '@tests/utils/crypto';
 import { expectToThrowFetchError } from '@tests/utils/fetch';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
-export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const crypto = await getCrypto();
+
   interface User {
     id: string;
     name: string;

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -302,14 +302,14 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
       headers.delete('accept');
 
       let deletionResponsePromise = fetch(`${baseURL}/users/${1}`, { method: 'DELETE', headers });
-      await expect(deletionResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(deletionResponsePromise);
       expect(deletionRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       deletionResponsePromise = fetch(`${baseURL}/users`, { method: 'DELETE', headers });
-      await expect(deletionResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(deletionResponsePromise);
       expect(deletionRequests).toHaveLength(2);
     });
   });
@@ -361,7 +361,7 @@ export function declareDeleteHttpInterceptorTests({ platform }: SharedHttpInterc
       searchParams.delete('tag');
 
       const listResponsePromise = fetch(`${baseURL}/users/${1}?${searchParams.toString()}`, { method: 'DELETE' });
-      await expect(listResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(listResponsePromise);
       expect(deletionRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -5,13 +5,16 @@ import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import { getCrypto } from '@tests/utils/crypto';
 import { expectToThrowFetchError } from '@tests/utils/fetch';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
-export function declareGetHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+export async function declareGetHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const crypto = await getCrypto();
+
   interface User {
     id: string;
     name: string;

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -13,10 +13,20 @@ import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
 export function declareGetHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    {
+      id: crypto.randomUUID(),
+      name: 'User 1',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'User 2',
+    },
+  ];
 
   const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
@@ -84,6 +94,7 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const user: User = {
+        id: crypto.randomUUID(),
         name: 'User (computed)',
       };
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -304,14 +304,14 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
       headers.delete('accept');
 
       let listResponsePromise = fetch(`${baseURL}/users`, { method: 'GET', headers });
-      await expect(listResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(listResponsePromise);
       expect(listRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       listResponsePromise = fetch(`${baseURL}/users`, { method: 'GET', headers });
-      await expect(listResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(listResponsePromise);
       expect(listRequests).toHaveLength(2);
     });
   });
@@ -374,14 +374,14 @@ export function declareGetHttpInterceptorTests({ platform }: SharedHttpIntercept
       searchParams.delete('orderBy');
 
       let listResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'GET' });
-      await expect(listResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(listResponsePromise);
       expect(listRequests).toHaveLength(1);
 
       searchParams.append('orderBy', 'name');
       searchParams.set('name', 'User 2');
 
       listResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'GET' });
-      await expect(listResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(listResponsePromise);
       expect(listRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -276,14 +276,14 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       headers.delete('accept');
 
       let headResponsePromise = fetch(`${baseURL}/users`, { method: 'HEAD', headers });
-      await expect(headResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(headResponsePromise);
       expect(headRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       headResponsePromise = fetch(`${baseURL}/users`, { method: 'HEAD', headers });
-      await expect(headResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(headResponsePromise);
       expect(headRequests).toHaveLength(2);
     });
   });
@@ -334,7 +334,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       searchParams.delete('tag');
 
       const headResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'HEAD' });
-      await expect(headResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(headResponsePromise);
       expect(headRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -102,6 +102,72 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
     });
   });
 
+  it('should support intercepting HEAD requests having headers', async () => {
+    type UserHeadRequestHeaders = HttpInterceptorSchema.Headers<{
+      accept?: string;
+    }>;
+    type UserHeadResponseHeaders = HttpInterceptorSchema.Headers<{
+      'content-type'?: `application/${string}`;
+      'cache-control'?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        HEAD: {
+          request: {
+            headers: UserHeadRequestHeaders;
+          };
+          response: {
+            200: {
+              headers: UserHeadResponseHeaders;
+            };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const headTracker = interceptor.head('/users').respond((request) => {
+        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserHeadRequestHeaders>>();
+        expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+        const acceptHeader = request.headers.get('accept')!;
+        expect(acceptHeader).toBe('application/json');
+
+        return {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'cache-control': 'no-cache',
+          },
+        };
+      });
+      expect(headTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const headRequests = headTracker.requests();
+      expect(headRequests).toHaveLength(0);
+
+      const headResponse = await fetch(`${baseURL}/users`, {
+        method: 'HEAD',
+        headers: {
+          accept: 'application/json',
+        } satisfies UserHeadRequestHeaders,
+      });
+      expect(headResponse.status).toBe(200);
+
+      expect(headRequests).toHaveLength(1);
+      const [headRequest] = headRequests;
+      expect(headRequest).toBeInstanceOf(Request);
+
+      expectTypeOf(headRequest.headers).toEqualTypeOf<HttpHeaders<UserHeadRequestHeaders>>();
+      expect(headRequest.headers).toBeInstanceOf(HttpHeaders);
+      expect(headRequest.headers.get('accept')).toBe('application/json');
+
+      expectTypeOf(headRequest.response.headers).toEqualTypeOf<HttpHeaders<UserHeadResponseHeaders>>();
+      expect(headRequest.response.headers).toBeInstanceOf(HttpHeaders);
+      expect(headRequest.response.headers.get('content-type')).toBe('application/json');
+      expect(headRequest.response.headers.get('cache-control')).toBe('no-cache');
+    });
+  });
+
   it('should support intercepting HEAD requests having search params', async () => {
     type UserHeadSearchParams = HttpInterceptorSchema.SearchParams<{
       tag?: string;
@@ -270,72 +336,6 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
       const headResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'HEAD' });
       await expect(headResponsePromise).rejects.toThrowError();
       expect(headRequests).toHaveLength(1);
-    });
-  });
-
-  it('should support intercepting HEAD requests having headers', async () => {
-    type UserHeadRequestHeaders = HttpInterceptorSchema.Headers<{
-      accept?: string;
-    }>;
-    type UserHeadResponseHeaders = HttpInterceptorSchema.Headers<{
-      'content-type'?: `application/${string}`;
-      'cache-control'?: string;
-    }>;
-
-    await usingHttpInterceptor<{
-      '/users': {
-        HEAD: {
-          request: {
-            headers: UserHeadRequestHeaders;
-          };
-          response: {
-            200: {
-              headers: UserHeadResponseHeaders;
-            };
-          };
-        };
-      };
-    }>({ worker, baseURL }, async (interceptor) => {
-      const headTracker = interceptor.head('/users').respond((request) => {
-        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserHeadRequestHeaders>>();
-        expect(request.headers).toBeInstanceOf(HttpHeaders);
-
-        const acceptHeader = request.headers.get('accept')!;
-        expect(acceptHeader).toBe('application/json');
-
-        return {
-          status: 200,
-          headers: {
-            'content-type': 'application/json',
-            'cache-control': 'no-cache',
-          },
-        };
-      });
-      expect(headTracker).toBeInstanceOf(HttpRequestTracker);
-
-      const headRequests = headTracker.requests();
-      expect(headRequests).toHaveLength(0);
-
-      const headResponse = await fetch(`${baseURL}/users`, {
-        method: 'HEAD',
-        headers: {
-          accept: 'application/json',
-        } satisfies UserHeadRequestHeaders,
-      });
-      expect(headResponse.status).toBe(200);
-
-      expect(headRequests).toHaveLength(1);
-      const [headRequest] = headRequests;
-      expect(headRequest).toBeInstanceOf(Request);
-
-      expectTypeOf(headRequest.headers).toEqualTypeOf<HttpHeaders<UserHeadRequestHeaders>>();
-      expect(headRequest.headers).toBeInstanceOf(HttpHeaders);
-      expect(headRequest.headers.get('accept')).toBe('application/json');
-
-      expectTypeOf(headRequest.response.headers).toEqualTypeOf<HttpHeaders<UserHeadResponseHeaders>>();
-      expect(headRequest.response.headers).toBeInstanceOf(HttpHeaders);
-      expect(headRequest.response.headers.get('content-type')).toBe('application/json');
-      expect(headRequest.response.headers.get('cache-control')).toBe('no-cache');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -291,14 +291,14 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       headers.delete('accept');
 
       let optionsResponsePromise = fetch(`${baseURL}/filters`, { method: 'OPTIONS', headers });
-      await expect(optionsResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(optionsResponsePromise);
       expect(optionsRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       optionsResponsePromise = fetch(`${baseURL}/users`, { method: 'OPTIONS', headers });
-      await expect(optionsResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(optionsResponsePromise);
       expect(optionsRequests).toHaveLength(2);
     });
   });
@@ -349,7 +349,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
       searchParams.delete('tag');
 
       const optionsResponsePromise = fetch(`${baseURL}/filters?${searchParams.toString()}`, { method: 'OPTIONS' });
-      await expect(optionsResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(optionsResponsePromise);
       expect(optionsRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -302,14 +302,14 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       headers.delete('accept');
 
       let updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PATCH', headers });
-      await expect(updateResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PATCH', headers });
-      await expect(updateResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
     });
   });
@@ -361,7 +361,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       searchParams.delete('tag');
 
       const updateResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
-      await expect(updateResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -16,10 +16,20 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    {
+      id: crypto.randomUUID(),
+      name: 'User 1',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'User 2',
+    },
+  ];
 
   beforeAll(async () => {
     await worker.start();
@@ -35,7 +45,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   it('should support intercepting PATCH requests with a static response body', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -43,7 +53,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond({
+      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -52,7 +62,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
@@ -75,23 +85,23 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   it('should support intercepting PATCH requests with a computed response body, based on the request body', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
-          request: { body: User };
+          request: { body: Partial<User> };
           response: {
             200: { body: User };
           };
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond((request) => {
-        expectTypeOf(request.body).toEqualTypeOf<User>();
+      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+        expectTypeOf(request.body).toEqualTypeOf<Partial<User>>();
+
+        const updatedUser: User = { ...users[0], ...request.body };
 
         return {
           status: 200,
-          body: {
-            name: request.body.name,
-          },
+          body: updatedUser,
         };
       });
       expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
@@ -101,27 +111,27 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
       const userName = 'User (other)';
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ name: userName } satisfies Partial<User>),
       });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
-      expect(updatedUsers).toEqual<User>({ name: userName });
+      expect(updatedUsers).toEqual<User>({ ...users[0], name: userName });
 
       expect(updateRequests).toHaveLength(1);
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<User>();
-      expect(updateRequest.body).toEqual<User>({ name: userName });
+      expectTypeOf(updateRequest.body).toEqualTypeOf<Partial<User>>();
+      expect(updateRequest.body).toEqual<Partial<User>>({ name: userName });
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
       expect(updateRequest.response.status).toEqual(200);
 
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
-      expect(updateRequest.response.body).toEqual<User>({ name: userName });
+      expect(updateRequest.response.body).toEqual<User>({ ...users[0], name: userName });
     });
   });
   it('should support intercepting PATCH requests having headers', async () => {
@@ -134,7 +144,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           request: {
             headers: UserUpdateRequestHeaders;
@@ -148,7 +158,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond((request) => {
+      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
         expect(request.headers).toBeInstanceOf(HttpHeaders);
 
@@ -169,7 +179,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
         headers: {
           accept: 'application/json',
@@ -198,7 +208,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           request: {
             searchParams: UserUpdateSearchParams;
@@ -209,7 +219,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond((request) => {
+      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
         expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
@@ -227,7 +237,9 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         tag: 'admin',
       });
 
-      const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}?${searchParams.toString()}`, {
+        method: 'PATCH',
+      });
       expect(updateResponse.status).toBe(200);
 
       expect(updateRequests).toHaveLength(1);
@@ -248,7 +260,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           request: {
             headers: UserUpdateHeaders;
@@ -260,7 +272,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch('/users')
+        .patch<'/users/:id'>(`/users/${users[0].id}`)
         .with({
           headers: { 'content-type': 'application/json' },
         })
@@ -289,26 +301,26 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         accept: 'application/json',
       });
 
-      let updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      let updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH', headers });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(1);
 
       headers.append('accept', 'application/xml');
 
-      updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH', headers });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(2);
 
       headers.delete('accept');
 
-      let updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      let updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH', headers });
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
-      updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PATCH', headers });
+      updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH', headers });
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
     });
@@ -320,7 +332,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           request: {
             searchParams: UserUpdateSearchParams;
@@ -332,7 +344,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch('/users')
+        .patch<'/users/:id'>(`/users/${users[0].id}`)
         .with({
           searchParams: { tag: 'admin' },
         })
@@ -354,13 +366,17 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         tag: 'admin',
       });
 
-      const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}?${searchParams.toString()}`, {
+        method: 'PATCH',
+      });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(1);
 
       searchParams.delete('tag');
 
-      const updateResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
+      const updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}?${searchParams.toString()}`, {
+        method: 'PATCH',
+      });
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(1);
     });
@@ -370,7 +386,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     type UserUpdateBody = HttpInterceptorSchema.Body<Partial<User>>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           request: {
             body: UserUpdateBody;
@@ -382,7 +398,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch('/users')
+        .patch<'/users/:id'>(`/users/${users[0].id}`)
         .with({
           body: { name: users[0].name },
         })
@@ -399,7 +415,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
         body: JSON.stringify({
           name: users[0].name,
@@ -408,7 +424,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(1);
 
-      let updateResponsePromise = fetch(`${baseURL}/users`, {
+      let updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
         body: JSON.stringify({
           name: users[1].name,
@@ -417,7 +433,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(1);
 
-      updateResponsePromise = fetch(`${baseURL}/users`, {
+      updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
         body: JSON.stringify({} satisfies UserUpdateBody),
       });
@@ -428,7 +444,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   it('should support intercepting PATCH requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
-      '/users/:id': {
+      '/users/:id/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -436,7 +452,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const genericUpdateTracker = interceptor.patch('/users/:id').respond({
+      const genericUpdateTracker = interceptor.patch('/users/:id/:id').respond({
         status: 200,
         body: users[0],
       });
@@ -445,7 +461,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const genericUpdateRequests = genericUpdateTracker.requests();
       expect(genericUpdateRequests).toHaveLength(0);
 
-      const genericUpdateResponse = await fetch(`${baseURL}/users/${1}`, { method: 'PATCH' });
+      const genericUpdateResponse = await fetch(`${baseURL}/users/:id/${1}`, { method: 'PATCH' });
       expect(genericUpdateResponse.status).toBe(200);
 
       const genericUpdatedUser = (await genericUpdateResponse.json()) as User;
@@ -466,7 +482,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
       genericUpdateTracker.bypass();
 
-      const specificUpdateTracker = interceptor.patch<'/users/:id'>(`/users/${1}`).respond({
+      const specificUpdateTracker = interceptor.patch<'/users/:id/:id'>(`/users/:id/${1}`).respond({
         status: 200,
         body: users[0],
       });
@@ -475,7 +491,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const specificUpdateRequests = specificUpdateTracker.requests();
       expect(specificUpdateRequests).toHaveLength(0);
 
-      const specificUpdateResponse = await fetch(`${baseURL}/users/${1}`, { method: 'PATCH' });
+      const specificUpdateResponse = await fetch(`${baseURL}/users/:id/${1}`, { method: 'PATCH' });
       expect(specificUpdateResponse.status).toBe(200);
 
       const specificUpdatedUser = (await specificUpdateResponse.json()) as User;
@@ -494,16 +510,16 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       expectTypeOf(specificUpdateRequest.response.body).toEqualTypeOf<User>();
       expect(specificUpdateRequest.response.body).toEqual(users[0]);
 
-      const unmatchedUpdatePromise = fetch(`${baseURL}/users/${2}`, { method: 'PATCH' });
+      const unmatchedUpdatePromise = fetch(`${baseURL}/users/:id/${2}`, { method: 'PATCH' });
       await expectToThrowFetchError(unmatchedUpdatePromise);
     });
   });
 
   it('should not intercept a PATCH request without a registered response', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
-          request: { body: User };
+          request: { body: Partial<User> };
           response: {
             200: { body: User };
           };
@@ -512,32 +528,32 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }>({ worker, baseURL }, async (interceptor) => {
       const userName = 'User (other)';
 
-      let updatePromise = fetch(`${baseURL}/users`, {
+      let updatePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ name: userName } satisfies Partial<User>),
       });
       await expectToThrowFetchError(updatePromise);
 
-      const updateTrackerWithoutResponse = interceptor.patch('/users');
+      const updateTrackerWithoutResponse = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`);
       expect(updateTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequestsWithoutResponse = updateTrackerWithoutResponse.requests();
       expect(updateRequestsWithoutResponse).toHaveLength(0);
 
       let [updateRequestWithoutResponse] = updateRequestsWithoutResponse;
-      expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
+      expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<Partial<User>>();
       expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
-      updatePromise = fetch(`${baseURL}/users`, {
+      updatePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ name: userName } satisfies Partial<User>),
       });
       await expectToThrowFetchError(updatePromise);
 
       expect(updateRequestsWithoutResponse).toHaveLength(0);
 
       [updateRequestWithoutResponse] = updateRequestsWithoutResponse;
-      expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
+      expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<Partial<User>>();
       expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
       const updateTrackerWithResponse = updateTrackerWithoutResponse.respond({
@@ -545,9 +561,9 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         body: users[0],
       });
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PATCH',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ name: userName } satisfies Partial<User>),
       });
       expect(updateResponse.status).toBe(200);
 
@@ -561,8 +577,8 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const [updateRequest] = updateRequestsWithResponse;
       expect(updateRequest).toBeInstanceOf(Request);
 
-      expectTypeOf(updateRequest.body).toEqualTypeOf<User>();
-      expect(updateRequest.body).toEqual<User>({ name: userName });
+      expectTypeOf(updateRequest.body).toEqualTypeOf<Partial<User>>();
+      expect(updateRequest.body).toEqual<Partial<User>>({ name: userName });
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
       expect(updateRequest.response.status).toEqual(200);
@@ -578,7 +594,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -588,7 +604,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch('/users')
+        .patch<'/users/:id'>(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -601,7 +617,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
@@ -620,7 +636,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.patch('/users').respond({
+      const errorUpdateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -628,7 +644,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const errorUpdateRequests = errorUpdateTracker.requests();
       expect(errorUpdateRequests).toHaveLength(0);
 
-      const otherUpdateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const otherUpdateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(otherUpdateResponse.status).toBe(500);
 
       const serverError = (await otherUpdateResponse.json()) as ServerErrorResponseBody;
@@ -657,7 +673,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
     }
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -667,7 +683,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch('/users')
+        .patch<'/users/:id'>(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -677,7 +693,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const initialUpdateRequests = updateTracker.requests();
       expect(initialUpdateRequests).toHaveLength(0);
 
-      const updatePromise = fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const updatePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       await expectToThrowFetchError(updatePromise);
 
       updateTracker.respond({
@@ -689,7 +705,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      let updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      let updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(updateResponse.status).toBe(200);
 
       let updatedUsers = (await updateResponse.json()) as User;
@@ -708,7 +724,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.patch('/users').respond({
+      const errorUpdateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -716,7 +732,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const errorUpdateRequests = errorUpdateTracker.requests();
       expect(errorUpdateRequests).toHaveLength(0);
 
-      const otherUpdateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const otherUpdateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(otherUpdateResponse.status).toBe(500);
 
       const serverError = (await otherUpdateResponse.json()) as ServerErrorResponseBody;
@@ -739,7 +755,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
       errorUpdateTracker.bypass();
 
-      updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(updateResponse.status).toBe(200);
 
       updatedUsers = (await updateResponse.json()) as User;
@@ -764,7 +780,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   it('should ignore all trackers after cleared when intercepting PATCH requests', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -772,7 +788,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond({
+      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -782,14 +798,14 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const initialUpdateRequests = updateTracker.requests();
       expect(initialUpdateRequests).toHaveLength(0);
 
-      const updatePromise = fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const updatePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       await expectToThrowFetchError(updatePromise);
     });
   });
 
   it('should support creating new trackers after cleared', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -797,14 +813,14 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      let updateTracker = interceptor.patch('/users').respond({
+      let updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
 
       interceptor.clear();
 
-      updateTracker = interceptor.patch('/users').respond({
+      updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[1],
       });
@@ -812,7 +828,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
@@ -835,7 +851,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
 
   it('should support reusing current trackers after cleared', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PATCH: {
           response: {
             200: { body: User };
@@ -843,7 +859,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond({
+      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -858,7 +874,7 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PATCH' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PATCH' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -5,13 +5,16 @@ import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import { getCrypto } from '@tests/utils/crypto';
 import { expectToThrowFetchError } from '@tests/utils/fetch';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
-export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const crypto = await getCrypto();
+
   const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -124,6 +124,73 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       expect(updateRequest.response.body).toEqual<User>({ name: userName });
     });
   });
+  it('should support intercepting PATCH requests having headers', async () => {
+    type UserUpdateRequestHeaders = HttpInterceptorSchema.Headers<{
+      accept?: string;
+    }>;
+    type UserUpdateResponseHeaders = HttpInterceptorSchema.Headers<{
+      'content-type'?: `application/${string}`;
+      'cache-control'?: string;
+    }>;
+
+    await usingHttpInterceptor<{
+      '/users': {
+        PATCH: {
+          request: {
+            headers: UserUpdateRequestHeaders;
+          };
+          response: {
+            200: {
+              headers: UserUpdateResponseHeaders;
+              body: User;
+            };
+          };
+        };
+      };
+    }>({ worker, baseURL }, async (interceptor) => {
+      const updateTracker = interceptor.patch('/users').respond((request) => {
+        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
+        expect(request.headers).toBeInstanceOf(HttpHeaders);
+
+        const acceptHeader = request.headers.get('accept')!;
+        expect(acceptHeader).toBe('application/json');
+
+        return {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'cache-control': 'no-cache',
+          },
+          body: users[0],
+        };
+      });
+      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
+
+      const updateRequests = updateTracker.requests();
+      expect(updateRequests).toHaveLength(0);
+
+      const updateResponse = await fetch(`${baseURL}/users`, {
+        method: 'PATCH',
+        headers: {
+          accept: 'application/json',
+        } satisfies UserUpdateRequestHeaders,
+      });
+      expect(updateResponse.status).toBe(200);
+
+      expect(updateRequests).toHaveLength(1);
+      const [updateRequest] = updateRequests;
+      expect(updateRequest).toBeInstanceOf(Request);
+
+      expectTypeOf(updateRequest.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
+      expect(updateRequest.headers).toBeInstanceOf(HttpHeaders);
+      expect(updateRequest.headers.get('accept')).toBe('application/json');
+
+      expectTypeOf(updateRequest.response.headers).toEqualTypeOf<HttpHeaders<UserUpdateResponseHeaders>>();
+      expect(updateRequest.response.headers).toBeInstanceOf(HttpHeaders);
+      expect(updateRequest.response.headers.get('content-type')).toBe('application/json');
+      expect(updateRequest.response.headers.get('cache-control')).toBe('no-cache');
+    });
+  });
 
   it('should support intercepting PATCH requests having search params', async () => {
     type UserUpdateSearchParams = HttpInterceptorSchema.SearchParams<{
@@ -296,74 +363,6 @@ export function declarePatchHttpInterceptorTests({ platform }: SharedHttpInterce
       const updateResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PATCH' });
       await expect(updateResponsePromise).rejects.toThrowError();
       expect(updateRequests).toHaveLength(1);
-    });
-  });
-
-  it('should support intercepting PATCH requests having headers', async () => {
-    type UserUpdateRequestHeaders = HttpInterceptorSchema.Headers<{
-      accept?: string;
-    }>;
-    type UserUpdateResponseHeaders = HttpInterceptorSchema.Headers<{
-      'content-type'?: `application/${string}`;
-      'cache-control'?: string;
-    }>;
-
-    await usingHttpInterceptor<{
-      '/users': {
-        PATCH: {
-          request: {
-            headers: UserUpdateRequestHeaders;
-          };
-          response: {
-            200: {
-              headers: UserUpdateResponseHeaders;
-              body: User;
-            };
-          };
-        };
-      };
-    }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch('/users').respond((request) => {
-        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
-        expect(request.headers).toBeInstanceOf(HttpHeaders);
-
-        const acceptHeader = request.headers.get('accept')!;
-        expect(acceptHeader).toBe('application/json');
-
-        return {
-          status: 200,
-          headers: {
-            'content-type': 'application/json',
-            'cache-control': 'no-cache',
-          },
-          body: users[0],
-        };
-      });
-      expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
-
-      const updateRequests = updateTracker.requests();
-      expect(updateRequests).toHaveLength(0);
-
-      const updateResponse = await fetch(`${baseURL}/users`, {
-        method: 'PATCH',
-        headers: {
-          accept: 'application/json',
-        } satisfies UserUpdateRequestHeaders,
-      });
-      expect(updateResponse.status).toBe(200);
-
-      expect(updateRequests).toHaveLength(1);
-      const [updateRequest] = updateRequests;
-      expect(updateRequest).toBeInstanceOf(Request);
-
-      expectTypeOf(updateRequest.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
-      expect(updateRequest.headers).toBeInstanceOf(HttpHeaders);
-      expect(updateRequest.headers.get('accept')).toBe('application/json');
-
-      expectTypeOf(updateRequest.response.headers).toEqualTypeOf<HttpHeaders<UserUpdateResponseHeaders>>();
-      expect(updateRequest.response.headers).toBeInstanceOf(HttpHeaders);
-      expect(updateRequest.response.headers.get('content-type')).toBe('application/json');
-      expect(updateRequest.response.headers.get('cache-control')).toBe('no-cache');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -5,13 +5,16 @@ import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import { getCrypto } from '@tests/utils/crypto';
 import { expectToThrowFetchError } from '@tests/utils/fetch';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
-export function declarePostHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+export async function declarePostHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const crypto = await getCrypto();
+
   const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -309,14 +309,14 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
       headers.delete('accept');
 
       let creationResponsePromise = fetch(`${baseURL}/users`, { method: 'POST', headers });
-      await expect(creationResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(creationResponsePromise);
       expect(creationRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       creationResponsePromise = fetch(`${baseURL}/users`, { method: 'POST', headers });
-      await expect(creationResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(creationResponsePromise);
       expect(creationRequests).toHaveLength(2);
     });
   });
@@ -368,7 +368,7 @@ export function declarePostHttpInterceptorTests({ platform }: SharedHttpIntercep
       searchParams.delete('tag');
 
       const creationResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'POST' });
-      await expect(creationResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(creationResponsePromise);
       expect(creationRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -302,14 +302,14 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       headers.delete('accept');
 
       let updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PUT', headers });
-      await expect(updateResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
       updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PUT', headers });
-      await expect(updateResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
     });
   });
@@ -361,7 +361,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       searchParams.delete('tag');
 
       const updateResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PUT' });
-      await expect(updateResponsePromise).rejects.toThrowError();
+      await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(1);
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -5,13 +5,16 @@ import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import HttpRequestTracker from '@/interceptor/http/requestTracker/HttpRequestTracker';
+import { getCrypto } from '@tests/utils/crypto';
 import { expectToThrowFetchError } from '@tests/utils/fetch';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorSchema } from '../../../types/schema';
 import { SharedHttpInterceptorTestsOptions } from '../interceptorTests';
 
-export function declarePutHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInterceptorTestsOptions) {
+  const crypto = await getCrypto();
+
   const worker = createHttpInterceptorWorker({ platform }) as HttpInterceptorWorker;
   const baseURL = 'http://localhost:3000';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -16,10 +16,20 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    {
+      id: crypto.randomUUID(),
+      name: 'User 1',
+    },
+    {
+      id: crypto.randomUUID(),
+      name: 'User 2',
+    },
+  ];
 
   beforeAll(async () => {
     await worker.start();
@@ -35,7 +45,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   it('should support intercepting PUT requests with a static response body', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -43,7 +53,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put('/users').respond({
+      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -52,7 +62,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
@@ -75,7 +85,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   it('should support intercepting PUT requests with a computed response body, based on the request body', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: { body: User };
           response: {
@@ -84,14 +94,14 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put('/users').respond((request) => {
+      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<User>();
+
+        const updatedUser: User = { ...users[0], ...request.body };
 
         return {
           status: 200,
-          body: {
-            name: request.body.name,
-          },
+          body: updatedUser,
         };
       });
       expect(updateTracker).toBeInstanceOf(HttpRequestTracker);
@@ -101,27 +111,27 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
       const userName = 'User (other)';
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ ...users[0], name: userName } satisfies User),
       });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
-      expect(updatedUsers).toEqual<User>({ name: userName });
+      expect(updatedUsers).toEqual<User>({ ...users[0], name: userName });
 
       expect(updateRequests).toHaveLength(1);
       const [updateRequest] = updateRequests;
       expect(updateRequest).toBeInstanceOf(Request);
 
       expectTypeOf(updateRequest.body).toEqualTypeOf<User>();
-      expect(updateRequest.body).toEqual<User>({ name: userName });
+      expect(updateRequest.body).toEqual<User>({ ...users[0], name: userName });
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
       expect(updateRequest.response.status).toEqual(200);
 
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
-      expect(updateRequest.response.body).toEqual<User>({ name: userName });
+      expect(updateRequest.response.body).toEqual<User>({ ...users[0], name: userName });
     });
   });
   it('should support intercepting PUT requests having headers', async () => {
@@ -134,7 +144,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: {
             headers: UserUpdateRequestHeaders;
@@ -148,7 +158,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put('/users').respond((request) => {
+      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
         expect(request.headers).toBeInstanceOf(HttpHeaders);
 
@@ -169,7 +179,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
         headers: {
           accept: 'application/json',
@@ -198,7 +208,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: {
             searchParams: UserUpdateSearchParams;
@@ -209,7 +219,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put('/users').respond((request) => {
+      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
         expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
@@ -227,7 +237,9 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         tag: 'admin',
       });
 
-      const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PUT' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}?${searchParams.toString()}`, {
+        method: 'PUT',
+      });
       expect(updateResponse.status).toBe(200);
 
       expect(updateRequests).toHaveLength(1);
@@ -248,7 +260,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: {
             headers: UserUpdateHeaders;
@@ -260,7 +272,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put('/users')
+        .put<'/users/:id'>(`/users/${users[0].id}`)
         .with({
           headers: { 'content-type': 'application/json' },
         })
@@ -289,26 +301,26 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         accept: 'application/json',
       });
 
-      let updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT', headers });
+      let updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT', headers });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(1);
 
       headers.append('accept', 'application/xml');
 
-      updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT', headers });
+      updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT', headers });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(2);
 
       headers.delete('accept');
 
-      let updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PUT', headers });
+      let updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT', headers });
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
 
       headers.set('accept', 'application/json');
       headers.set('content-type', 'text/plain');
 
-      updateResponsePromise = fetch(`${baseURL}/users`, { method: 'PUT', headers });
+      updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT', headers });
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(2);
     });
@@ -320,7 +332,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: {
             searchParams: UserUpdateSearchParams;
@@ -332,7 +344,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put('/users')
+        .put<'/users/:id'>(`/users/${users[0].id}`)
         .with({
           searchParams: { tag: 'admin' },
         })
@@ -354,13 +366,17 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         tag: 'admin',
       });
 
-      const updateResponse = await fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PUT' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}?${searchParams.toString()}`, {
+        method: 'PUT',
+      });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(1);
 
       searchParams.delete('tag');
 
-      const updateResponsePromise = fetch(`${baseURL}/users?${searchParams.toString()}`, { method: 'PUT' });
+      const updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}?${searchParams.toString()}`, {
+        method: 'PUT',
+      });
       await expectToThrowFetchError(updateResponsePromise);
       expect(updateRequests).toHaveLength(1);
     });
@@ -370,7 +386,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     type UserUpdateBody = HttpInterceptorSchema.Body<User>;
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: {
             body: UserUpdateBody;
@@ -382,9 +398,9 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put('/users')
+        .put<'/users/:id'>(`/users/${users[0].id}`)
         .with({
-          body: { name: users[0].name },
+          body: { ...users[0], name: users[1].name },
         })
         .respond((request) => {
           expectTypeOf(request.body).toEqualTypeOf<UserUpdateBody>();
@@ -399,19 +415,21 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
         body: JSON.stringify({
-          name: users[0].name,
+          ...users[0],
+          name: users[1].name,
         } satisfies UserUpdateBody),
       });
       expect(updateResponse.status).toBe(200);
       expect(updateRequests).toHaveLength(1);
 
-      const updateResponsePromise = fetch(`${baseURL}/users`, {
+      const updateResponsePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
         body: JSON.stringify({
-          name: users[1].name,
+          ...users[0],
+          name: users[0].name,
         } satisfies UserUpdateBody),
       });
       await expectToThrowFetchError(updateResponsePromise);
@@ -421,7 +439,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   it('should support intercepting PUT requests with a dynamic path', async () => {
     await usingHttpInterceptor<{
-      '/users/:id': {
+      '/users/:id/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -429,7 +447,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const genericUpdateTracker = interceptor.put('/users/:id').respond({
+      const genericUpdateTracker = interceptor.put('/users/:id/:id').respond({
         status: 200,
         body: users[0],
       });
@@ -438,7 +456,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const genericUpdateRequests = genericUpdateTracker.requests();
       expect(genericUpdateRequests).toHaveLength(0);
 
-      const genericUpdateResponse = await fetch(`${baseURL}/users/${1}`, { method: 'PUT' });
+      const genericUpdateResponse = await fetch(`${baseURL}/users/${users[0].id}/${1}`, { method: 'PUT' });
       expect(genericUpdateResponse.status).toBe(200);
 
       const genericUpdatedUser = (await genericUpdateResponse.json()) as User;
@@ -459,7 +477,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
       genericUpdateTracker.bypass();
 
-      const specificUpdateTracker = interceptor.put<'/users/:id'>(`/users/${1}`).respond({
+      const specificUpdateTracker = interceptor.put<'/users/:id/:id'>(`/users/:id/${1}`).respond({
         status: 200,
         body: users[0],
       });
@@ -468,7 +486,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const specificUpdateRequests = specificUpdateTracker.requests();
       expect(specificUpdateRequests).toHaveLength(0);
 
-      const specificUpdateResponse = await fetch(`${baseURL}/users/${1}`, { method: 'PUT' });
+      const specificUpdateResponse = await fetch(`${baseURL}/users/${users[0].id}/${1}`, { method: 'PUT' });
       expect(specificUpdateResponse.status).toBe(200);
 
       const specificUpdatedUser = (await specificUpdateResponse.json()) as User;
@@ -487,14 +505,14 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       expectTypeOf(specificUpdateRequest.response.body).toEqualTypeOf<User>();
       expect(specificUpdateRequest.response.body).toEqual(users[0]);
 
-      const unmatchedUpdatePromise = fetch(`${baseURL}/users/${2}`, { method: 'PUT' });
+      const unmatchedUpdatePromise = fetch(`${baseURL}/users/${users[0].id}/${2}`, { method: 'PUT' });
       await expectToThrowFetchError(unmatchedUpdatePromise);
     });
   });
 
   it('should not intercept a PUT request without a registered response', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           request: { body: User };
           response: {
@@ -505,13 +523,13 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }>({ worker, baseURL }, async (interceptor) => {
       const userName = 'User (other)';
 
-      let updatePromise = fetch(`${baseURL}/users`, {
+      let updatePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ ...users[0], name: userName } satisfies User),
       });
       await expectToThrowFetchError(updatePromise);
 
-      const updateTrackerWithoutResponse = interceptor.put('/users');
+      const updateTrackerWithoutResponse = interceptor.put<'/users/:id'>(`/users/${users[0].id}`);
       expect(updateTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequestsWithoutResponse = updateTrackerWithoutResponse.requests();
@@ -521,9 +539,9 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       expectTypeOf<typeof updateRequestWithoutResponse.body>().toEqualTypeOf<User>();
       expectTypeOf<typeof updateRequestWithoutResponse.response>().toEqualTypeOf<never>();
 
-      updatePromise = fetch(`${baseURL}/users`, {
+      updatePromise = fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ ...users[0], name: userName } satisfies User),
       });
       await expectToThrowFetchError(updatePromise);
 
@@ -538,9 +556,9 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         body: users[0],
       });
 
-      const updateResponse = await fetch(`${baseURL}/users`, {
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, {
         method: 'PUT',
-        body: JSON.stringify({ name: userName } satisfies User),
+        body: JSON.stringify({ ...users[0], name: userName } satisfies User),
       });
       expect(updateResponse.status).toBe(200);
 
@@ -555,7 +573,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       expect(updateRequest).toBeInstanceOf(Request);
 
       expectTypeOf(updateRequest.body).toEqualTypeOf<User>();
-      expect(updateRequest.body).toEqual<User>({ name: userName });
+      expect(updateRequest.body).toEqual<User>({ ...users[0], name: userName });
 
       expectTypeOf(updateRequest.response.status).toEqualTypeOf<200>();
       expect(updateRequest.response.status).toEqual(200);
@@ -571,7 +589,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -581,7 +599,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put('/users')
+        .put<'/users/:id'>(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -594,7 +612,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
@@ -613,7 +631,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.put('/users').respond({
+      const errorUpdateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -621,7 +639,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const errorUpdateRequests = errorUpdateTracker.requests();
       expect(errorUpdateRequests).toHaveLength(0);
 
-      const otherUpdateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      const otherUpdateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(otherUpdateResponse.status).toBe(500);
 
       const serverError = (await otherUpdateResponse.json()) as ServerErrorResponseBody;
@@ -650,7 +668,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
     }
 
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -660,7 +678,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put('/users')
+        .put<'/users/:id'>(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -670,7 +688,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const initialUpdateRequests = updateTracker.requests();
       expect(initialUpdateRequests).toHaveLength(0);
 
-      const updatePromise = fetch(`${baseURL}/users`, { method: 'PUT' });
+      const updatePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       await expectToThrowFetchError(updatePromise);
 
       updateTracker.respond({
@@ -682,7 +700,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      let updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      let updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(updateResponse.status).toBe(200);
 
       let createdUsers = (await updateResponse.json()) as User;
@@ -701,7 +719,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.put('/users').respond({
+      const errorUpdateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -709,7 +727,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const errorUpdateRequests = errorUpdateTracker.requests();
       expect(errorUpdateRequests).toHaveLength(0);
 
-      const otherUpdateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      const otherUpdateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(otherUpdateResponse.status).toBe(500);
 
       const serverError = (await otherUpdateResponse.json()) as ServerErrorResponseBody;
@@ -732,7 +750,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
       errorUpdateTracker.bypass();
 
-      updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(updateResponse.status).toBe(200);
 
       createdUsers = (await updateResponse.json()) as User;
@@ -757,7 +775,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   it('should ignore all trackers after cleared when intercepting PUT requests', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -765,7 +783,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put('/users').respond({
+      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -775,14 +793,14 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const initialUpdateRequests = updateTracker.requests();
       expect(initialUpdateRequests).toHaveLength(0);
 
-      const updatePromise = fetch(`${baseURL}/users`, { method: 'PUT' });
+      const updatePromise = fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       await expectToThrowFetchError(updatePromise);
     });
   });
 
   it('should support creating new trackers after cleared', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -790,14 +808,14 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      let updateTracker = interceptor.put('/users').respond({
+      let updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
 
       interceptor.clear();
 
-      updateTracker = interceptor.put('/users').respond({
+      updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[1],
       });
@@ -805,7 +823,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;
@@ -828,7 +846,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
 
   it('should support reusing current trackers after cleared', async () => {
     await usingHttpInterceptor<{
-      '/users': {
+      '/users/:id': {
         PUT: {
           response: {
             200: { body: User };
@@ -836,7 +854,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put('/users').respond({
+      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -851,7 +869,7 @@ export function declarePutHttpInterceptorTests({ platform }: SharedHttpIntercept
       const updateRequests = updateTracker.requests();
       expect(updateRequests).toHaveLength(0);
 
-      const updateResponse = await fetch(`${baseURL}/users`, { method: 'PUT' });
+      const updateResponse = await fetch(`${baseURL}/users/${users[0].id}`, { method: 'PUT' });
       expect(updateResponse.status).toBe(200);
 
       const updatedUsers = (await updateResponse.json()) as User;

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -49,21 +49,16 @@ export interface HttpInterceptorSchema {
 
 export namespace HttpInterceptorSchema {
   export type Root<Schema extends HttpInterceptorSchema> = Prettify<Schema>;
-
   export type Path<Schema extends HttpInterceptorPathSchema> = Prettify<Schema>;
-
   export type Method<Schema extends HttpInterceptorMethodSchema> = Prettify<Schema>;
 
   export type Request<Schema extends HttpInterceptorRequestSchema> = Prettify<Schema>;
-  export type RequestBody<Schema extends HttpInterceptorBodySchema> = Prettify<Schema>;
-
   export type Response<Schema extends HttpInterceptorResponseSchema> = Prettify<Schema>;
-  export type ResponseBody<Schema extends HttpInterceptorBodySchema> = Prettify<Schema>;
-
   export type ResponseByStatusCode<Schema extends HttpInterceptorResponseSchemaByStatusCode> = Prettify<Schema>;
 
   export type Headers<Schema extends HttpInterceptorHeadersSchema> = Prettify<Schema>;
   export type SearchParams<Schema extends HttpInterceptorSearchParamsSchema> = Prettify<Schema>;
+  export type Body<Schema extends HttpInterceptorBodySchema> = Prettify<Schema>;
 }
 
 export type ExtractHttpInterceptorSchema<Interceptor> =

--- a/packages/zimic/src/interceptor/http/requestTracker/__tests__/shared/requestTrackerTests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/__tests__/shared/requestTrackerTests.ts
@@ -39,7 +39,10 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
       request: {
         headers: HeadersSchema;
         searchParams: SearchParamsSchema;
-        body: { success?: undefined };
+        body: {
+          name?: string;
+          value?: number[];
+        };
       };
       response: {
         200: {
@@ -50,7 +53,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
 
     type Schema = HttpInterceptorSchema.Root<{
       '/users': {
-        GET: MethodSchema;
+        POST: MethodSchema;
       };
     }>;
 
@@ -66,17 +69,17 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should provide access to the method and path', () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
-      expectTypeOf<typeof tracker.method>().toEqualTypeOf<() => 'GET'>();
-      expect(tracker.method()).toBe('GET');
+      expectTypeOf<typeof tracker.method>().toEqualTypeOf<() => 'POST'>();
+      expect(tracker.method()).toBe('POST');
 
       expectTypeOf<typeof tracker.path>().toEqualTypeOf<() => '/users'>();
       expect(tracker.path()).toBe('/users');
     });
 
     it('should not match any request if contains no declared response', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
       const request = new Request(baseURL);
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
@@ -84,7 +87,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should match any request if contains a declared response and no restrictions', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users').respond({
         status: 200,
         body: { success: true },
       });
@@ -99,7 +102,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should not match any request if bypassed', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
       const request = new Request(baseURL);
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
@@ -125,7 +128,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should not match any request if cleared', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
       const request = new Request(baseURL);
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
@@ -154,7 +157,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
       const responseStatus = 200;
       const responseBody = { success: true } as const;
 
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users').respond({
         status: responseStatus,
         body: responseBody,
       });
@@ -179,7 +182,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
         body: responseBody,
       }));
 
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
       tracker.respond(responseFactory);
 
       const request = new Request(baseURL);
@@ -193,7 +196,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should throw an error if trying to create a response without a declared response', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
       const request = new Request(baseURL);
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
@@ -204,7 +207,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should keep track of the intercepted requests and responses', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users').respond({
         status: 200,
         body: { success: true },
       });
@@ -254,7 +257,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should clear the intercepted requests and responses after cleared', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users').respond({
         status: 200,
         body: { success: true },
       });
@@ -286,14 +289,14 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should provide access to the raw intercepted requests and responses', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users').respond({
         status: 200,
         body: { success: true },
       });
 
       const request = new Request(baseURL, {
         method: 'POST',
-        body: JSON.stringify({ success: undefined } satisfies MethodSchema['request']['body']),
+        body: JSON.stringify({ name: 'User' } satisfies MethodSchema['request']['body']),
       });
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
 
@@ -308,13 +311,13 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
 
       expect(interceptedRequests[0]).toEqual(parsedRequest);
 
-      expectTypeOf(interceptedRequests[0].raw).toEqualTypeOf<HttpRequest<{ success?: undefined }>>();
+      expectTypeOf(interceptedRequests[0].raw).toEqualTypeOf<HttpRequest<MethodSchema['request']['body']>>();
       expect(interceptedRequests[0].raw).toBeInstanceOf(Request);
       expect(interceptedRequests[0].raw.url).toBe(`${baseURL}/`);
       expect(interceptedRequests[0].raw.method).toBe('POST');
       expect(interceptedRequests[0].raw.headers).toEqual(request.headers);
-      expectTypeOf(interceptedRequests[0].raw.json).toEqualTypeOf<() => Promise<{ success?: undefined }>>();
-      expect(await interceptedRequests[0].raw.json()).toEqual<MethodSchema['request']['body']>({ success: undefined });
+      expectTypeOf(interceptedRequests[0].raw.json).toEqualTypeOf<() => Promise<MethodSchema['request']['body']>>();
+      expect(await interceptedRequests[0].raw.json()).toEqual<MethodSchema['request']['body']>({ name: 'User' });
 
       expect(interceptedRequests[0].response).toEqual(parsedResponse);
 
@@ -329,7 +332,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should provide no access to hidden properties in raw intercepted requests and responses', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users').respond({
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users').respond({
         status: 200,
         body: { success: true },
       });
@@ -368,7 +371,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
           async ({ exact }) => {
             const name = 'User';
 
-            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+            const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
               .with({
                 searchParams: { name },
                 exact,
@@ -401,7 +404,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
           async ({ exact }) => {
             const name = 'User';
 
-            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+            const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
               .with({
                 searchParams: { name },
                 exact,
@@ -434,7 +437,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
         it('should match only specific requests if contains a declared response and a computed search params restriction', async () => {
           const name = 'User';
 
-          const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+          const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
             .with((request) => {
               expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<SearchParamsSchema>>();
               expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
@@ -474,7 +477,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
           async ({ exact }) => {
             const contentType = 'application/json';
 
-            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+            const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
               .with({
                 headers: { 'content-type': contentType },
                 exact,
@@ -507,7 +510,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
           async ({ exact }) => {
             const contentType = 'application/json';
 
-            const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+            const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
               .with({
                 headers: { 'content-type': contentType },
                 exact,
@@ -540,7 +543,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
         it('should match only specific requests if contains a declared response and a computed header restriction', async () => {
           const contentType = 'application/json';
 
-          const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+          const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
             .with((request) => {
               expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<HeadersSchema>>();
               expect(request.headers).toBeInstanceOf(HttpHeaders);
@@ -574,11 +577,128 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
         });
       });
 
+      describe('By body', () => {
+        it.each([{ exact: true }])(
+          'should match only specific requests if contains a declared response, a static body restriction, and exact: $exact',
+          async ({ exact }) => {
+            const name = 'User';
+
+            const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
+              .with({
+                body: { name },
+                exact,
+              })
+              .respond({
+                status: 200,
+                body: { success: true },
+              });
+
+            for (const matchingBody of [{ name }] satisfies MethodSchema['request']['body'][]) {
+              const matchingRequest = new Request(baseURL, {
+                method: 'POST',
+                body: JSON.stringify(matchingBody),
+              });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+            }
+
+            for (const mismatchingBody of [
+              { name, value: [] },
+              { name, value: [1, 2] },
+              {},
+            ] satisfies MethodSchema['request']['body'][]) {
+              const request = new Request(baseURL, {
+                method: 'POST',
+                body: JSON.stringify(mismatchingBody),
+              });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+            }
+          },
+        );
+
+        it.each([{ exact: false }, { exact: undefined }])(
+          'should match only specific requests if contains a declared response, a static header restriction, and exact: $exact',
+          async ({ exact }) => {
+            const name = 'User';
+
+            const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
+              .with({
+                body: { name },
+                exact,
+              })
+              .respond({
+                status: 200,
+                body: { success: true },
+              });
+
+            for (const matchingBody of [
+              { name },
+              { name, value: [] },
+              { name, value: [1, 2] },
+            ] satisfies MethodSchema['request']['body'][]) {
+              const matchingRequest = new Request(baseURL, {
+                method: 'POST',
+                body: JSON.stringify(matchingBody),
+              });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+            }
+
+            for (const mismatchingBody of [{}] satisfies MethodSchema['request']['body'][]) {
+              const request = new Request(baseURL, {
+                method: 'POST',
+                body: JSON.stringify(mismatchingBody),
+              });
+              const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+              expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+            }
+          },
+        );
+
+        it('should match only specific requests if contains a declared response and a computed body restriction', async () => {
+          const name = 'User';
+
+          const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
+            .with((request) => {
+              expectTypeOf(request.body).toEqualTypeOf<MethodSchema['request']['body']>();
+
+              return request.body.name?.startsWith(name) ?? false;
+            })
+            .respond({
+              status: 200,
+              body: { success: true },
+            });
+
+          for (const matchingBody of [
+            { name },
+            { name, value: [1] },
+            { name: `${name}-other` },
+          ] satisfies MethodSchema['request']['body'][]) {
+            const matchingRequest = new Request(baseURL, {
+              method: 'POST',
+              body: JSON.stringify(matchingBody),
+            });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(matchingRequest);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(true);
+          }
+
+          for (const mismatchingBody of [{ name: `Other ${name}` }, {}] satisfies MethodSchema['request']['body'][]) {
+            const request = new Request(baseURL, {
+              method: 'POST',
+              body: JSON.stringify(mismatchingBody),
+            });
+            const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
+            expect(tracker.matchesRequest(parsedRequest)).toBe(false);
+          }
+        });
+      });
+
       it('should match only specific requests if contains a declared response and multiple restrictions', async () => {
         const name = 'User';
         const contentType = 'application/json';
 
-        const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users')
+        const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users')
           .with({
             headers: { 'content-type': contentType },
             searchParams: { name },
@@ -666,7 +786,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should clear restrictions after cleared', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
       const request = new Request(baseURL);
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);
@@ -694,7 +814,7 @@ export function declareSharedHttpRequestTrackerTests(options: { platform: HttpIn
     });
 
     it('should not clear restrictions after bypassed', async () => {
-      const tracker = new HttpRequestTracker<Schema, 'GET', '/users'>(interceptor, 'GET', '/users');
+      const tracker = new HttpRequestTracker<Schema, 'POST', '/users'>(interceptor, 'POST', '/users');
 
       const request = new Request(baseURL);
       const parsedRequest = await HttpInterceptorWorker.parseRawRequest<MethodSchema>(request);

--- a/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/public.ts
@@ -9,29 +9,36 @@ import {
   HttpInterceptorSchemaPath,
 } from '../../interceptor/types/schema';
 import {
-  HttpHeadersRequestSchema,
+  HttpRequestHeadersSchema,
   HttpInterceptorRequest,
   HttpRequestTrackerResponseDeclaration,
   HttpRequestTrackerResponseDeclarationFactory,
-  HttpSearchParamsRequestSchema,
+  HttpRequestSearchParamsSchema,
   TrackedHttpInterceptorRequest,
+  HttpRequestBodySchema,
 } from './requests';
-
-export type HttpRequestTrackerSearchParamsStaticRestriction<
-  Schema extends HttpInterceptorSchema,
-  Path extends HttpInterceptorSchemaPath<Schema, Method>,
-  Method extends HttpInterceptorSchemaMethod<Schema>,
-> =
-  | HttpSearchParamsRequestSchema<Default<Schema[Path][Method]>>
-  | HttpSearchParams<HttpSearchParamsRequestSchema<Default<Schema[Path][Method]>>>;
 
 export type HttpRequestTrackerHeadersStaticRestriction<
   Schema extends HttpInterceptorSchema,
   Path extends HttpInterceptorSchemaPath<Schema, Method>,
   Method extends HttpInterceptorSchemaMethod<Schema>,
 > =
-  | HttpHeadersRequestSchema<Default<Schema[Path][Method]>>
-  | HttpHeaders<HttpHeadersRequestSchema<Default<Schema[Path][Method]>>>;
+  | HttpRequestHeadersSchema<Default<Schema[Path][Method]>>
+  | HttpHeaders<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
+
+export type HttpRequestTrackerSearchParamsStaticRestriction<
+  Schema extends HttpInterceptorSchema,
+  Path extends HttpInterceptorSchemaPath<Schema, Method>,
+  Method extends HttpInterceptorSchemaMethod<Schema>,
+> =
+  | HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>
+  | HttpSearchParams<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
+
+export type HttpRequestTrackerBodyStaticRestriction<
+  Schema extends HttpInterceptorSchema,
+  Path extends HttpInterceptorSchemaPath<Schema, Method>,
+  Method extends HttpInterceptorSchemaMethod<Schema>,
+> = HttpRequestBodySchema<Default<Schema[Path][Method]>>;
 
 export interface HttpRequestTrackerStaticRestriction<
   Schema extends HttpInterceptorSchema,
@@ -40,6 +47,7 @@ export interface HttpRequestTrackerStaticRestriction<
 > {
   headers?: HttpRequestTrackerHeadersStaticRestriction<Schema, Path, Method>;
   searchParams?: HttpRequestTrackerSearchParamsStaticRestriction<Schema, Path, Method>;
+  body?: HttpRequestTrackerBodyStaticRestriction<Schema, Path, Method>;
   exact?: boolean;
 }
 

--- a/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/requests.ts
@@ -33,30 +33,45 @@ export type HttpRequestTrackerResponseDeclarationFactory<
   request: Omit<HttpInterceptorRequest<MethodSchema>, 'response'>,
 ) => PossiblePromise<HttpRequestTrackerResponseDeclaration<MethodSchema, StatusCode>>;
 
-export type HttpHeadersRequestSchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
+export type HttpRequestHeadersSchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
   Default<MethodSchema['request'], { headers: never }>['headers']
 >;
 
-export type HttpSearchParamsRequestSchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
+export type HttpRequestSearchParamsSchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
   Default<MethodSchema['request'], { searchParams: never }>['searchParams']
+>;
+
+export type HttpRequestBodySchema<MethodSchema extends HttpInterceptorMethodSchema> = Default<
+  Default<MethodSchema['request'], { body: null }>['body'],
+  null
 >;
 
 export interface HttpInterceptorRequest<MethodSchema extends HttpInterceptorMethodSchema>
   extends Omit<HttpRequest, keyof Body | 'headers'> {
-  headers: HttpHeaders<HttpHeadersRequestSchema<MethodSchema>>;
-  searchParams: HttpSearchParams<HttpSearchParamsRequestSchema<MethodSchema>>;
-  body: Default<Default<MethodSchema['request'], { body: null }>['body'], null>;
+  headers: HttpHeaders<HttpRequestHeadersSchema<MethodSchema>>;
+  searchParams: HttpSearchParams<HttpRequestSearchParamsSchema<MethodSchema>>;
+  body: HttpRequestBodySchema<MethodSchema>;
   raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;
 }
+
+export type HttpResponseHeadersSchema<
+  MethodSchema extends HttpInterceptorMethodSchema,
+  StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+> = Default<Default<MethodSchema['response']>[StatusCode]['headers']>;
+
+export type HttpResponseBodySchema<
+  MethodSchema extends HttpInterceptorMethodSchema,
+  StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+> = Default<Default<MethodSchema['response']>[StatusCode]['body'], null>;
 
 export interface HttpInterceptorResponse<
   MethodSchema extends HttpInterceptorMethodSchema,
   StatusCode extends HttpInterceptorResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > extends Omit<HttpResponse, keyof Body | 'headers'> {
-  headers: HttpHeaders<Default<Default<MethodSchema['response']>[StatusCode]['headers']>>;
+  headers: HttpHeaders<HttpResponseHeadersSchema<MethodSchema, StatusCode>>;
   status: StatusCode;
-  body: Default<Default<MethodSchema['response']>[StatusCode]['body'], null>;
-  raw: HttpResponse<Default<Default<MethodSchema['response']>[StatusCode]['body'], null>, StatusCode>;
+  body: HttpResponseBodySchema<MethodSchema, StatusCode>;
+  raw: HttpResponse<HttpResponseBodySchema<MethodSchema, StatusCode>, StatusCode>;
 }
 
 export const HTTP_INTERCEPTOR_REQUEST_HIDDEN_BODY_PROPERTIES = new Set<

--- a/packages/zimic/src/types/arrays.d.ts
+++ b/packages/zimic/src/types/arrays.d.ts
@@ -1,0 +1,5 @@
+interface ArrayConstructor {
+  // Using the original method signature style to correctly apply the overload.
+  // eslint-disable-next-line @typescript-eslint/method-signature-style
+  isArray<Item>(value: unknown): value is Item[];
+}

--- a/packages/zimic/src/utils/__tests__/json.test.ts
+++ b/packages/zimic/src/utils/__tests__/json.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+
+import { jsonContains, jsonEquals } from '../json';
+
+describe('JSON utilities', () => {
+  describe('Equality', () => {
+    it('should correctly compare numbers', () => {
+      expect(jsonEquals(1, 1)).toBe(true);
+
+      expect(jsonEquals(1, 2)).toBe(false);
+      expect(jsonEquals(2, 1)).toBe(false);
+    });
+
+    it('should correctly compare strings', () => {
+      expect(jsonEquals('', '')).toBe(true);
+      expect(jsonEquals('a', 'a')).toBe(true);
+
+      expect(jsonEquals('a', 'b')).toBe(false);
+      expect(jsonEquals('b', 'a')).toBe(false);
+      expect(jsonEquals('aaa', 'aab')).toBe(false);
+      expect(jsonEquals('aab', 'aaa')).toBe(false);
+    });
+
+    it('should correctly compare booleans', () => {
+      expect(jsonEquals(true, true)).toBe(true);
+      expect(jsonEquals(false, false)).toBe(true);
+
+      expect(jsonEquals(true, false)).toBe(false);
+      expect(jsonEquals(false, true)).toBe(false);
+    });
+
+    it('should correctly compare null and undefined', () => {
+      expect(jsonEquals(null, null)).toBe(true);
+      expect(jsonEquals(undefined, undefined)).toBe(true);
+
+      expect(jsonEquals(null, undefined)).toBe(false);
+      expect(jsonEquals(undefined, null)).toBe(false);
+    });
+
+    it('should correctly compare arrays', () => {
+      expect(jsonEquals([], [])).toBe(true);
+      expect(jsonEquals([1], [1])).toBe(true);
+      expect(jsonEquals([1, 2], [1, 2])).toBe(true);
+
+      expect(jsonEquals([1, 2], [2, 1])).toBe(false);
+      expect(jsonEquals([1, 2], [1, 2, 3])).toBe(false);
+      expect(jsonEquals([1, 2, 3], [1, 2])).toBe(false);
+      expect(jsonEquals([1, 2], [1])).toBe(false);
+      expect(jsonEquals([1], [1, 2])).toBe(false);
+    });
+
+    it('should correctly compare objects', () => {
+      expect(jsonEquals({}, {})).toBe(true);
+      expect(jsonEquals({ a: 1 }, { a: 1 })).toBe(true);
+      expect(jsonEquals({ a: 1, b: '2' }, { a: 1, b: '2' })).toBe(true);
+      expect(jsonEquals({ a: 1, b: '2' }, { b: '2', a: 1 })).toBe(true);
+
+      expect(jsonEquals({ a: 1, b: '2' }, { a: 1 })).toBe(false);
+      expect(jsonEquals({ a: 1 }, { a: 1, b: '2' })).toBe(false);
+      expect(jsonEquals({ a: 1, b: '2' }, { a: 1, b: '3' })).toBe(false);
+      expect(jsonEquals({ a: 1, b: '2' }, { a: '2', b: '2' })).toBe(false);
+    });
+
+    it('should correctly compare nested arrays', () => {
+      expect(jsonEquals([[]], [[]])).toBe(true);
+      expect(jsonEquals([[1, 2]], [[1, 2]])).toBe(true);
+      expect(jsonEquals([[1], [2, 3]], [[1], [2, 3]])).toBe(true);
+
+      expect(jsonEquals([[1, 2]], [[2, 1]])).toBe(false);
+      expect(jsonEquals([[1, 2]], [[1, 2, 3]])).toBe(false);
+      expect(jsonEquals([[1, 2, 3]], [[1, 2]])).toBe(false);
+      expect(jsonEquals([[1, 2]], [[1]])).toBe(false);
+      expect(jsonEquals([[1]], [[1, 2]])).toBe(false);
+      expect(jsonEquals([[1], [2, 3]], [[1]])).toBe(false);
+      expect(jsonEquals([[1], [2, 3]], [[2, 3]])).toBe(false);
+    });
+
+    it('should correctly compare nested objects', () => {
+      expect(jsonEquals({ a: { b: 1 } }, { a: { b: 1 } })).toBe(true);
+      expect(jsonEquals({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '2' } })).toBe(true);
+      expect(jsonEquals({ a: { b: 1, c: '2' } }, { a: { c: '2', b: 1 } })).toBe(true);
+
+      expect(jsonEquals({ a: { b: 1, c: '2' } }, { a: { b: 1 } })).toBe(false);
+      expect(jsonEquals({ a: { b: 1 } }, { a: { b: 1, c: '2' } })).toBe(false);
+      expect(jsonEquals({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '3' } })).toBe(false);
+      expect(jsonEquals({ a: { b: 1, c: '2' } }, { a: { b: '2', c: '2' } })).toBe(false);
+    });
+
+    it('should correctly compare mixed values', () => {
+      expect(jsonEquals({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '3' }] })).toBe(true);
+      expect(jsonEquals({ a: [1, 2, { b: ['3'] }] }, { a: [1, 2, { b: ['3'] }] })).toBe(true);
+      expect(jsonEquals({ a: [1, 2, [{ b: '3' }]] }, { a: [1, 2, [{ b: '3' }]] })).toBe(true);
+
+      expect(jsonEquals({ a: [1, 2, { b: ['3'] }] }, { a: [1, 2, { b: '3' }] })).toBe(false);
+      expect(jsonEquals({ a: [1, 2, [{ b: '3' }]] }, { a: [1, 2, [{ b: '2' }, { b: '3' }]] })).toBe(false);
+      expect(jsonEquals({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '4' }] })).toBe(false);
+      expect(jsonEquals({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { c: '3' }] })).toBe(false);
+      expect(jsonEquals({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '3' }, 4] })).toBe(false);
+      expect(jsonEquals({ a: [1, 2, { b: '3' }, 4] }, { a: [1, 2, { b: '3' }] })).toBe(false);
+      expect(jsonEquals({ b: ['3'] }, { b: { c: '3' } })).toBe(false);
+      expect(jsonEquals({ b: { c: '3' } }, { b: ['3'] })).toBe(false);
+    });
+  });
+
+  describe('Containment', () => {
+    it('should correctly compare numbers', () => {
+      expect(jsonContains(1, 1)).toBe(true);
+
+      expect(jsonContains(1, 2)).toBe(false);
+      expect(jsonContains(2, 1)).toBe(false);
+    });
+
+    it('should correctly compare strings', () => {
+      expect(jsonContains('', '')).toBe(true);
+      expect(jsonContains('a', 'a')).toBe(true);
+
+      expect(jsonContains('a', 'b')).toBe(false);
+      expect(jsonContains('b', 'a')).toBe(false);
+      expect(jsonContains('aaa', 'aab')).toBe(false);
+      expect(jsonContains('aab', 'aaa')).toBe(false);
+    });
+
+    it('should correctly compare booleans', () => {
+      expect(jsonContains(true, true)).toBe(true);
+      expect(jsonContains(false, false)).toBe(true);
+
+      expect(jsonContains(true, false)).toBe(false);
+      expect(jsonContains(false, true)).toBe(false);
+    });
+
+    it('should correctly compare null and undefined', () => {
+      expect(jsonContains(null, null)).toBe(true);
+      expect(jsonContains(undefined, undefined)).toBe(true);
+
+      expect(jsonContains(null, undefined)).toBe(false);
+      expect(jsonContains(undefined, null)).toBe(false);
+    });
+
+    it('should correctly compare arrays', () => {
+      expect(jsonContains([], [])).toBe(true);
+      expect(jsonContains([1], [1])).toBe(true);
+      expect(jsonContains([1, 2], [1, 2])).toBe(true);
+      expect(jsonContains([1, 2, 3], [1, 2])).toBe(true);
+      expect(jsonContains([1, 2, 3], [1, 3])).toBe(true);
+      expect(jsonContains([1, 2, 3], [2, 3])).toBe(true);
+      expect(jsonContains([1, 2, 3], [1, 2, 3])).toBe(true);
+      expect(jsonContains([1, 2], [1])).toBe(true);
+
+      expect(jsonContains([1, 2], [2, 1])).toBe(false);
+      expect(jsonContains([2, 3], [1, 2, 3])).toBe(false);
+      expect(jsonContains([1], [1, 2])).toBe(false);
+      expect(jsonContains([1, 2], [1, 2, 3])).toBe(false);
+      expect(jsonContains([1, 2], [1, 3, 2])).toBe(false);
+      expect(jsonContains([1, 2], [3, 1, 2])).toBe(false);
+    });
+
+    it('should correctly compare objects', () => {
+      expect(jsonContains({}, {})).toBe(true);
+      expect(jsonContains({ a: 1 }, { a: 1 })).toBe(true);
+      expect(jsonContains({ a: 1, b: '2' }, {})).toBe(true);
+      expect(jsonContains({ a: 1, b: '2' }, { a: 1, b: '2' })).toBe(true);
+      expect(jsonContains({ a: 1, b: '2' }, { b: '2', a: 1 })).toBe(true);
+      expect(jsonContains({ a: 1, b: '2' }, { a: 1 })).toBe(true);
+      expect(jsonContains({ a: 1, b: '2' }, { b: '2' })).toBe(true);
+
+      expect(jsonContains({ a: 1, b: '2' }, { a: 1, b: '2', c: '3' })).toBe(false);
+      expect(jsonContains({ a: 1, b: '2' }, { a: 1, b: '3' })).toBe(false);
+      expect(jsonContains({ a: 1, b: '2' }, { a: 1, c: '2' })).toBe(false);
+      expect(jsonContains({ a: 1, b: '2' }, { b: '3' })).toBe(false);
+      expect(jsonContains({ a: 1, b: '2' }, { c: '3' })).toBe(false);
+    });
+
+    it('should correctly compare nested arrays', () => {
+      expect(jsonContains([[]], [[]])).toBe(true);
+      expect(jsonContains([[1, 2, 3]], [[1, 2]])).toBe(true);
+      expect(jsonContains([[1, 2], 3], [[1, 2]])).toBe(true);
+      expect(jsonContains([[1, 2, 3]], [[1, 2]])).toBe(true);
+      expect(jsonContains([[1], [2, 3]], [[1], [2, 3]])).toBe(true);
+      expect(jsonContains([[1, 2]], [[1]])).toBe(true);
+      expect(jsonContains([[1], [2, 3]], [[1]])).toBe(true);
+      expect(jsonContains([[1], [2, 3]], [[2, 3]])).toBe(true);
+
+      expect(jsonContains([[1, 2]], [[2, 1]])).toBe(false);
+      expect(jsonContains([[1, 2]], [[1, 2, 3]])).toBe(false);
+      expect(jsonContains([[1]], [[1, 2]])).toBe(false);
+      expect(jsonContains([[1], [2, 3]], [[2, 3], [1]])).toBe(false);
+    });
+
+    it('should correctly compare nested objects', () => {
+      expect(jsonContains({ a: { b: 1 } }, { a: { b: 1 } })).toBe(true);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1 } })).toBe(true);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { c: '2' } })).toBe(true);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '2' } })).toBe(true);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { c: '2', b: 1 } })).toBe(true);
+      expect(jsonContains({ a: { b: 1, c: '2', d: '3' } }, { a: { b: 1, c: '2' } })).toBe(true);
+
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '3' } })).toBe(false);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '2', d: '3' } })).toBe(false);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '3', d: '4' } })).toBe(false);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '3', d: '4' } })).toBe(false);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '3', d: '4' } })).toBe(false);
+      expect(jsonContains({ a: { b: 1, c: '2' } }, { a: { b: 1, c: '3', d: '4' } })).toBe(false);
+    });
+
+    it('should correctly compare mixed values', () => {
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '3' }] })).toBe(true);
+      expect(jsonContains({ a: [1, 2, { b: ['3'] }] }, { a: [1, 2, { b: ['3'] }] })).toBe(true);
+      expect(jsonContains({ a: [1, 2, [{ b: '3' }]] }, { a: [1, 2, [{ b: '3' }]] })).toBe(true);
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 2] })).toBe(true);
+      expect(jsonContains({ a: [1, 2, { b: '3' }, 4] }, { a: [1, 2, { b: '3' }] })).toBe(true);
+
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 2, 3] })).toBe(false);
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 3, 2] })).toBe(false);
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [3, 1, 2] })).toBe(false);
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '3' }, 4] })).toBe(false);
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '2' }, { b: '3' }] })).toBe(false);
+      expect(jsonContains({ a: [1, 2, { b: '3' }] }, { a: [1, 2, { b: '2' }, { b: '3' }, 4] })).toBe(false);
+      expect(jsonContains({ b: ['3'] }, { b: { c: '3' } })).toBe(false);
+      expect(jsonContains({ b: { c: '3' } }, { b: ['3'] })).toBe(false);
+    });
+  });
+});

--- a/packages/zimic/src/utils/json.ts
+++ b/packages/zimic/src/utils/json.ts
@@ -1,0 +1,87 @@
+import { JSONValue } from '..';
+
+function isPrimitiveJSONValue<Value extends JSONValue>(value: Value): value is Exclude<Value, object> {
+  return typeof value !== 'object' || value === null;
+}
+
+export function jsonEquals(value: JSONValue, otherValue: JSONValue): boolean {
+  if (isPrimitiveJSONValue(value)) {
+    return value === otherValue;
+  }
+  if (isPrimitiveJSONValue(otherValue)) {
+    return false;
+  }
+
+  if (Array.isArray<JSONValue>(value)) {
+    if (!Array.isArray<JSONValue>(otherValue)) {
+      return false;
+    }
+    if (value.length !== otherValue.length) {
+      return false;
+    }
+    return value.every((item, index) => jsonEquals(item, otherValue[index]));
+  }
+
+  if (Array.isArray(otherValue)) {
+    return false;
+  }
+
+  const valueKeys = Object.keys(value);
+  const otherValueKeys = Object.keys(otherValue);
+
+  if (valueKeys.length !== otherValueKeys.length) {
+    return false;
+  }
+
+  return valueKeys.every((key) => {
+    const subValue = value[key as keyof typeof value];
+    const subOtherValue = otherValue[key as keyof typeof otherValue];
+    return jsonEquals(subValue, subOtherValue);
+  });
+}
+
+export function jsonContains(value: JSONValue, otherValue: JSONValue): boolean {
+  if (isPrimitiveJSONValue(value)) {
+    return value === otherValue;
+  }
+  if (isPrimitiveJSONValue(otherValue)) {
+    return false;
+  }
+
+  if (Array.isArray<JSONValue>(value)) {
+    if (!Array.isArray<JSONValue>(otherValue)) {
+      return false;
+    }
+    if (value.length < otherValue.length) {
+      return false;
+    }
+
+    let lastMatchedIndex = -1;
+    return otherValue.every((otherItem) => {
+      for (let index = lastMatchedIndex + 1; index < value.length; index++) {
+        if (jsonContains(value[index], otherItem)) {
+          lastMatchedIndex = index;
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
+  if (Array.isArray(otherValue)) {
+    return false;
+  }
+
+  const valueKeys = Object.keys(value);
+  const otherValueKeys = Object.keys(otherValue);
+
+  if (valueKeys.length < otherValueKeys.length) {
+    return false;
+  }
+
+  return otherValueKeys.every((key) => {
+    const subValue = value[key as keyof typeof value];
+    const subOtherValue = otherValue[key as keyof typeof otherValue];
+    return jsonContains(subValue, subOtherValue);
+  });
+}

--- a/packages/zimic/tests/utils/crypto.ts
+++ b/packages/zimic/tests/utils/crypto.ts
@@ -1,0 +1,6 @@
+export async function getCrypto() {
+  const globalCrypto = globalThis.crypto as Crypto | undefined;
+  /* istanbul ignore next -- @preserve
+   * Ignoring as Node.js >=20 provides a global crypto and the import fallback won't run. */
+  return globalCrypto ?? (await import('node:crypto'));
+}


### PR DESCRIPTION
### Features
- [#zimic] Added support to restrict request trackers by body.

```ts
const creationTracker = authInterceptor
  .post('/users')
  .with({
    body: creationPayload,
  })
  .respond((request) => {
    const user: User = {
      id: crypto.randomUUID(),
      name: request.body.name,
      email: request.body.email,
    };

    return {
      status: 201,
      body: user,
    };
  });

const response = await createUser(creationPayload);
expect(response.status).toBe(201);
```

### Refactoring
- [#zimic] Simplified request and response body schemas.
  - Unified `HttpInterceptorSchema.RequestBody` and `HttpInterceptorSchema.ResponseBody` into `HttpInterceptorSchema.Body`, as the previous `RequestBody` and `ResponseBody` had the same semantics.
- [#zimic] Improved HTTP interceptor test scenarios, following real-world cases more closely for each method.
Closes #12.