### PR TITLE
chore: typescript CI matrix (#68)

### DIFF
--- a/.github/actions/zimic-setup/action.yaml
+++ b/.github/actions/zimic-setup/action.yaml
@@ -69,8 +69,6 @@ runs:
       id: install-dependencies
       shell: bash
       run: |
-        workspaceRootInstallFlag='--filter zimic-root'
-
         function composeFilterOptions() {
           filterEntries=${*}
           filterOptions=()
@@ -82,13 +80,26 @@ runs:
           echo "${filterOptions[@]}"
         }
 
-        partialInstallFlag="$(composeFilterOptions ${{ inputs.install }})"
-        installFlag="$workspaceRootInstallFlag $partialInstallFlag"
-        echo "install-filters=$installFlag" >> $GITHUB_OUTPUT
+        if [[ ${{ inputs.install }} == '' ]]; then
+          workspaceRootInstallFlag=''
+          partialInstallFlag=''
+          installFlag=''
+        else
+          workspaceRootInstallFlag='--filter zimic-root'
+          partialInstallFlag="$(composeFilterOptions ${{ inputs.install }})"
+          installFlag="$workspaceRootInstallFlag $partialInstallFlag"
+        fi
 
+        echo "install-filters=$installFlag" >> $GITHUB_OUTPUT
         pnpm install --prefer-offline --frozen-lockfile --ignore-scripts $installFlag
 
-        buildFlag="$(composeFilterOptions ${{ inputs.build }})"
+
+        if [[ ${{ inputs.build }} == '' ]]; then
+          buildFlag=''
+        else
+          buildFlag="$(composeFilterOptions ${{ inputs.build }})"
+        fi
+
         echo "build-filters=$buildFlag" >> $GITHUB_OUTPUT
         NODE_ENV='${{ inputs.build-node-env }}' pnpm turbo build $buildFlag
 

--- a/.github/actions/zimic-setup/action.yaml
+++ b/.github/actions/zimic-setup/action.yaml
@@ -80,7 +80,7 @@ runs:
           echo "${filterOptions[@]}"
         }
 
-        if [[ ${{ inputs.install }} == '' ]]; then
+        if [[ '${{ inputs.install }}' == '' ]]; then
           workspaceRootInstallFlag=''
           partialInstallFlag=''
           installFlag=''
@@ -93,8 +93,7 @@ runs:
         echo "install-filters=$installFlag" >> $GITHUB_OUTPUT
         pnpm install --prefer-offline --frozen-lockfile --ignore-scripts $installFlag
 
-
-        if [[ ${{ inputs.build }} == '' ]]; then
+        if [[ '${{ inputs.build }}' == '' ]]; then
           buildFlag=''
         else
           buildFlag="$(composeFilterOptions ${{ inputs.build }})"

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -27,6 +27,9 @@ jobs:
           - 18
           - 20
 
+    env:
+      NODE_VERSION: ${{ matrix.node-version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ concurrency:
 
 env:
   CI: true
+  IS_PULL_REQUEST_TO_MAIN:
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && 'true' || 'false' }}
   TURBO_LOG_ORDER: stream
   TURBO_TOKEN:
     ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') &&
@@ -28,16 +30,15 @@ env:
     "{./packages/*}[HEAD^1]..."' || './packages/*' }}
 
 jobs:
-  ci:
-    name: CI
+  ci-general:
+    name: CI (general)
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
         node-version:
-          - 18
           - 20
 
     env:
@@ -58,9 +59,7 @@ jobs:
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}
           build: ${{ env.BUILD_OPTIONS }}
-          build-node-env:
-            ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && 'development'
-            || 'production' }}
+          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
           install-playwright-browsers: true
 
       - name: Check formatting style
@@ -74,7 +73,7 @@ jobs:
             types:check lint:turbo \
             --continue \
             --concurrency 100% \
-            ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && steps.zimic-setup.outputs.install-filters || '' }}
+            ${{ steps.zimic-setup.outputs.install-filters }}
 
       - name: Run tests
         run: |
@@ -82,4 +81,104 @@ jobs:
             test:turbo \
             --continue \
             --concurrency 100% \
-            ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && steps.zimic-setup.outputs.install-filters || '' }}
+            ${{ steps.zimic-setup.outputs.install-filters }}
+
+  ci-node-compatibility:
+    name: CI (Node.js compatibility)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18
+
+    env:
+      NODE_VERSION: ${{ matrix.node-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Zimic
+        id: zimic-setup
+        uses: ./.github/actions/zimic-setup
+        with:
+          node-version: ${{ matrix.node-version }}
+          turbo-token: ${{ env.TURBO_TOKEN }}
+          turbo-team: ${{ env.TURBO_TEAM }}
+          install: ${{ env.INSTALL_OPTIONS }} !@zimic/release
+          build: ${{ env.BUILD_OPTIONS }} !@zimic/release
+          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
+          install-playwright-browsers: true
+
+      - name: Run tests
+        run: |
+          pnpm turbo \
+            test:turbo \
+            --continue \
+            --concurrency 100% \
+            ${{ steps.zimic-setup.outputs.install-filters }} \
+            --filter !@zimic/release
+
+  ci-typescript-compatibility:
+    name: CI (TypeScript compatibility)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20
+        typescript-version:
+          - 4.7
+          - 4.8
+          - 4.9
+          - 5.0
+          - 5.1
+          - 5.2
+          - 5.3
+          - 5.4
+
+    env:
+      NODE_VERSION: ${{ matrix.node-version }}
+      TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Zimic
+        id: zimic-setup
+        uses: ./.github/actions/zimic-setup
+        with:
+          node-version: ${{ matrix.node-version }}
+          turbo-token: ${{ env.TURBO_TOKEN }}
+          turbo-team: ${{ env.TURBO_TEAM }}
+          install: ${{ env.INSTALL_OPTIONS }} !packages/*
+          build: ${{ env.BUILD_OPTIONS }} !packages/*
+          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
+          install-playwright-browsers: false
+
+      - name: Set TypeScript version
+        run: |
+          pnpm update \
+            typescript@${{ matrix.typescript-version }} \
+            --recursive \
+            --filter zimic-test-client \
+            --filter zimic-example-*
+
+      - name: Check types
+        run: |
+          pnpm turbo \
+            types:check \
+            --continue \
+            --concurrency 100% \
+            ${{ steps.zimic-setup.outputs.install-filters }} \
+            --filter '!packages/*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,8 +97,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
-          install: ${{ env.INSTALL_OPTIONS }} !@zimic/release
-          build: ${{ env.BUILD_OPTIONS }} !@zimic/release
+          install: ${{ env.INSTALL_OPTIONS }}
+          build: ${{ env.BUILD_OPTIONS }}
           build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
           install-playwright-browsers: true
 
@@ -108,8 +108,7 @@ jobs:
             test:turbo \
             --continue \
             --concurrency 100% \
-            ${{ steps.zimic-setup.outputs.install-filters }} \
-            --filter !@zimic/release
+            ${{ steps.zimic-setup.outputs.install-filters }}
 
   ci-typescript:
     name: CI TypeScript

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,5 +164,4 @@ jobs:
             types:check \
             --continue \
             --concurrency 100% \
-            ${{ steps.zimic-setup.outputs.install-filters }} \
-            --filter '!packages/*'
+            ${{ steps.zimic-setup.outputs.install-filters }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,8 +145,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
-          install: ${{ env.INSTALL_OPTIONS }} !packages/*
-          build: ${{ env.BUILD_OPTIONS }} !packages/*
+          install: ${{ env.INSTALL_OPTIONS }}
+          build: ${{ env.BUILD_OPTIONS }}
           build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
           install-playwright-browsers: false
 
@@ -155,8 +155,9 @@ jobs:
           pnpm update \
             typescript@${{ matrix.typescript-version }} \
             --recursive \
-            --filter zimic-test-client \
-            --filter zimic-example-*
+            ${{ steps.zimic-setup.outputs.install-filters }} \
+            --filter !zimic \
+            --filter !@zimic/*
 
       - name: Check types
         run: |
@@ -164,4 +165,6 @@ jobs:
             types:check \
             --continue \
             --concurrency 100% \
-            ${{ steps.zimic-setup.outputs.install-filters }}
+            ${{ steps.zimic-setup.outputs.install-filters }} \
+            --filter !zimic \
+            --filter !@zimic/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,46 @@ env:
 
 jobs:
   ci-general:
-    name: CI (general)
+    name: CI General
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      NODE_VERSION: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Zimic
+        id: zimic-setup
+        uses: ./.github/actions/zimic-setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          turbo-token: ${{ env.TURBO_TOKEN }}
+          turbo-team: ${{ env.TURBO_TEAM }}
+          install: ${{ env.INSTALL_OPTIONS }}
+          build: ${{ env.BUILD_OPTIONS }}
+          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
+          install-playwright-browsers: true
+
+      - name: Check formatting style
+        uses: ./.github/actions/zimic-style-check
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Lint code and check types
+        run: |
+          pnpm turbo \
+            types:check lint:turbo \
+            --continue \
+            --concurrency 100% \
+            ${{ steps.zimic-setup.outputs.install-filters }}
+
+  ci-node:
+    name: CI Node.js
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -39,6 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
           - 20
 
     env:
@@ -54,60 +94,7 @@ jobs:
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:
-          node-version: ${{ matrix.node-version }}
-          turbo-token: ${{ env.TURBO_TOKEN }}
-          turbo-team: ${{ env.TURBO_TEAM }}
-          install: ${{ env.INSTALL_OPTIONS }}
-          build: ${{ env.BUILD_OPTIONS }}
-          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
-          install-playwright-browsers: true
-
-      - name: Check formatting style
-        uses: ./.github/actions/zimic-style-check
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Lint code and check types
-        run: |
-          pnpm turbo \
-            types:check lint:turbo \
-            --continue \
-            --concurrency 100% \
-            ${{ steps.zimic-setup.outputs.install-filters }}
-
-      - name: Run tests
-        run: |
-          pnpm turbo \
-            test:turbo \
-            --continue \
-            --concurrency 100% \
-            ${{ steps.zimic-setup.outputs.install-filters }}
-
-  ci-node-compatibility:
-    name: CI (Node.js compatibility)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - 18
-
-    env:
-      NODE_VERSION: ${{ matrix.node-version }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Setup Zimic
-        id: zimic-setup
-        uses: ./.github/actions/zimic-setup
-        with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }} !@zimic/release
@@ -124,16 +111,14 @@ jobs:
             ${{ steps.zimic-setup.outputs.install-filters }} \
             --filter !@zimic/release
 
-  ci-typescript-compatibility:
-    name: CI (TypeScript compatibility)
+  ci-typescript:
+    name: CI TypeScript
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - 20
         typescript-version:
           - 4.7
           - 4.8
@@ -145,7 +130,7 @@ jobs:
           - 5.4
 
     env:
-      NODE_VERSION: ${{ matrix.node-version }}
+      NODE_VERSION: 20
       TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}
 
     steps:
@@ -158,7 +143,7 @@ jobs:
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }} !packages/*

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/superagent/utils.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/superagent/utils.ts
@@ -22,7 +22,7 @@ export async function superagentAsFetch(request: Request): Promise<Response> {
       throw error;
     }
 
-    const superagentResponse = error.response as SuperagentResponse;
+    const { response: superagentResponse } = error as Error & { response: SuperagentResponse };
 
     return new Response(superagentResponse.text, {
       status: superagentResponse.status,

--- a/examples/package.json
+++ b/examples/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@zimic/eslint-config-node": "workspace:*",
     "@zimic/lint-staged-config": "workspace:*",
-    "@zimic/tsconfig": "workspace:*",
-    "typescript": "^5.4.3"
+    "@zimic/tsconfig": "workspace:*"
   }
 }

--- a/examples/with-jest-node/package.json
+++ b/examples/with-jest-node/package.json
@@ -8,7 +8,7 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
-    "fastify": "^4.26.1",
+    "fastify": "4.23.2",
     "zimic": "latest",
     "zod": "^3.22.4"
   },

--- a/examples/with-vitest-node/package.json
+++ b/examples/with-vitest-node/package.json
@@ -8,7 +8,7 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
-    "fastify": "^4.26.1",
+    "fastify": "4.23.2",
     "zimic": "latest",
     "zod": "^3.22.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ importers:
       '@zimic/tsconfig':
         specifier: workspace:*
         version: link:../packages/tsconfig
-      typescript:
-        specifier: ^5.4.3
-        version: 5.4.3
 
   examples/with-jest-jsdom:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
   examples/with-jest-node:
     dependencies:
       fastify:
-        specifier: ^4.26.1
-        version: 4.26.1
+        specifier: 4.23.2
+        version: 4.23.2
       zimic:
         specifier: latest
         version: link:../../packages/zimic
@@ -222,8 +222,8 @@ importers:
   examples/with-vitest-node:
     dependencies:
       fastify:
-        specifier: ^4.26.1
-        version: 4.26.1
+        specifier: 4.23.2
+        version: 4.23.2
       zimic:
         specifier: latest
         version: link:../../packages/zimic
@@ -4415,8 +4415,8 @@ packages:
     resolution: {integrity: sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw==}
     dev: false
 
-  /fastify@4.26.1:
-    resolution: {integrity: sha512-tznA/G55dsxzM5XChBfcvVSloG2ejeeotfPPJSFaWmHyCDVGMpvf3nRNbsCb/JTBF9RmQFBfuujWt3Nphjesng==}
+  /fastify@4.23.2:
+    resolution: {integrity: sha512-WFSxsHES115svC7NrerNqZwwM0UOxbC/P6toT9LRHgAAFvG7o2AN5W+H4ihCtOGuYXjZf4z+2jXC89rVEoPWOA==}
     dependencies:
       '@fastify/ajv-compiler': 3.5.0
       '@fastify/error': 3.4.1
@@ -4425,14 +4425,14 @@ packages:
       avvio: 8.3.0
       fast-content-type-parse: 1.1.0
       fast-json-stringify: 5.12.0
-      find-my-way: 8.1.0
+      find-my-way: 7.7.0
       light-my-request: 5.11.0
       pino: 8.18.0
-      process-warning: 3.0.0
+      process-warning: 2.3.2
       proxy-addr: 2.0.7
-      rfdc: 1.3.0
+      rfdc: 1.3.1
       secure-json-parse: 2.7.0
-      semver: 7.5.4
+      semver: 7.6.0
       toad-cache: 3.7.0
     transitivePeerDependencies:
       - supports-color
@@ -4483,8 +4483,8 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
-  /find-my-way@8.1.0:
-    resolution: {integrity: sha512-41QwjCGcVTODUmLLqTMeoHeiozbMXYMAE1CKFiDyi9zVZ2Vjh0yz3MF0WQZoIb+cmzP/XlbFjlF2NtJmvZHznA==}
+  /find-my-way@7.7.0:
+    resolution: {integrity: sha512-+SrHpvQ52Q6W9f3wJoJBbAQULJuNEEQwBvlvYwACDhBTLOTMiQ0HYWh4+vC3OivGP2ENcTI1oKlFA2OepJNjhQ==}
     engines: {node: '>=14'}
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7073,7 +7073,6 @@ packages:
 
   /rfdc@1.3.1:
     resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
-    dev: true
 
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -7199,6 +7198,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /semver@7.6.0:
     resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["NODE_ENV", "NODE_VERSION"],
+  "globalEnv": ["NODE_ENV", "NODE_VERSION", "TYPESCRIPT_VERSION"],
   "pipeline": {
     "dev": {
       "cache": false,


### PR DESCRIPTION
### CI/CD
- Added matrices to test Zimic's compatibility with Node.js 18 and 20 and TypeScript 4.7 to 5.4.

Closes #68;