### PR TITLE
feat: inferred dynamic paths (#123)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -554,7 +554,7 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
       }
 
       it('should support getting users by id', async () => {
-        const getTracker = authInterceptor.get<'/users/:id'>(`/users/${user.id}`).respond({
+        const getTracker = authInterceptor.get(`/users/${user.id}`).respond({
           status: 200,
           body: serializeUser(user),
         });
@@ -632,7 +632,7 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
       }
 
       it('should support deleting users by id', async () => {
-        const deleteTracker = authInterceptor.delete<'/users/:id'>(`/users/${user.id}`).respond({
+        const deleteTracker = authInterceptor.delete(`/users/${user.id}`).respond({
           status: 204,
         });
 
@@ -667,7 +667,7 @@ function declareDefaultClientTests(options: ClientTestDeclarationOptions) {
           code: 'not_found',
           message: 'User not found',
         };
-        const getTracker = authInterceptor.delete<'/users/:id'>(`/users/${user.id}`).respond({
+        const getTracker = authInterceptor.delete(`/users/${user.id}`).respond({
           status: 404,
           body: notFoundError,
         });

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -100,6 +100,27 @@ export type NonLiteralHttpServiceSchemaPath<
   Method extends HttpServiceSchemaMethod<Schema>,
 > = AllowAnyStringInPathParameters<LiteralHttpServiceSchemaPath<Schema, Method>>;
 
+type RecursiveNonLiteralHttpServiceSchemaPathToLiteral<
+  Schema extends HttpServiceSchema,
+  Method extends HttpServiceSchemaMethod<Schema>,
+  NonLiteralPath extends string,
+  LiteralPath extends LiteralHttpServiceSchemaPath<Schema, Method>,
+> =
+  NonLiteralPath extends AllowAnyStringInPathParameters<LiteralPath>
+    ? NonLiteralPath extends `${AllowAnyStringInPathParameters<LiteralPath>}/${string}`
+      ? never
+      : LiteralPath
+    : never;
+
+export type NonLiteralHttpServiceSchemaPathToLiteral<
+  Schema extends HttpServiceSchema,
+  Method extends HttpServiceSchemaMethod<Schema>,
+  NonLiteralPath extends string,
+  LiteralPath extends LiteralHttpServiceSchemaPath<Schema, Method> = LiteralHttpServiceSchemaPath<Schema, Method>,
+> = LiteralPath extends LiteralPath
+  ? RecursiveNonLiteralHttpServiceSchemaPathToLiteral<Schema, Method, NonLiteralPath, LiteralPath>
+  : never;
+
 /** Extracts the paths from an HTTP service schema containing certain methods. */
 export type HttpServiceSchemaPath<Schema extends HttpServiceSchema, Method extends HttpServiceSchemaMethod<Schema>> =
   | LiteralHttpServiceSchemaPath<Schema, Method>

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/baseURLs.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/baseURLs.ts
@@ -40,7 +40,7 @@ export function declareBaseURLHttpInterceptorTests(options: SharedHttpIntercepto
     }>({ worker, baseURL }, async (interceptor) => {
       expect(interceptor.baseURL()).toBe(baseURL);
 
-      const tracker = interceptor.get<':any'>(path).respond({
+      const tracker = interceptor.get(path).respond({
         status: 200,
       });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -57,7 +57,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const deletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const deletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -98,7 +98,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const deletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const deletionTracker = interceptor.delete(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<Partial<User>>();
 
         return {
@@ -475,7 +475,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const genericDeletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const genericDeletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -505,7 +505,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
 
       genericDeletionTracker.bypass();
 
-      const specificDeletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const specificDeletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -627,7 +627,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const deletionTracker = interceptor
-        .delete<'/users/:id'>(`/users/${users[0].id}`)
+        .delete(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -659,7 +659,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
       expectTypeOf(deletionRequest.response.body).toEqualTypeOf<User>();
       expect(deletionRequest.response.body).toEqual(users[1]);
 
-      const errorDeletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const errorDeletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -706,7 +706,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const deletionTracker = interceptor
-        .delete<'/users/:id'>(`/users/${users[0].id}`)
+        .delete(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -747,7 +747,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
       expectTypeOf(deletionRequest.response.body).toEqualTypeOf<User>();
       expect(deletionRequest.response.body).toEqual(users[1]);
 
-      const errorDeletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const errorDeletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -811,7 +811,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const deletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const deletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -836,14 +836,14 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      let deletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      let deletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
 
       interceptor.clear();
 
-      deletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      deletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[1],
       });
@@ -882,7 +882,7 @@ export async function declareDeleteHttpInterceptorTests({ platform }: SharedHttp
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const deletionTracker = interceptor.delete<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const deletionTracker = interceptor.delete(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -441,7 +441,7 @@ export async function declareGetHttpInterceptorTests({ platform }: SharedHttpInt
 
       genericGetTracker.bypass();
 
-      const specificGetTracker = interceptor.get<'/users/:id'>(`/users/${1}`).respond({
+      const specificGetTracker = interceptor.get(`/users/${1}`).respond({
         status: 200,
         body: users[0],
       });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -376,7 +376,7 @@ export function declareHeadHttpInterceptorTests({ platform }: SharedHttpIntercep
 
       genericHeadTracker.bypass();
 
-      const specificHeadTracker = interceptor.head<'/users/:id'>(`/users/${1}`).respond({
+      const specificHeadTracker = interceptor.head(`/users/${1}`).respond({
         status: 200,
       });
       expect(specificHeadTracker).toBeInstanceOf(HttpRequestTracker);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -471,7 +471,7 @@ export function declareOptionsHttpInterceptorTests({ platform }: SharedHttpInter
 
       genericOptionsTracker.bypass();
 
-      const specificOptionsTracker = interceptor.options<'/filters/:id'>(`/filters/${1}`).respond({
+      const specificOptionsTracker = interceptor.options(`/filters/${1}`).respond({
         status: 200,
       });
       expect(specificOptionsTracker).toBeInstanceOf(HttpRequestTracker);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -57,7 +57,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const updateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -98,7 +98,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const updateTracker = interceptor.patch(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<Partial<User>>();
 
         const updatedUser: User = { ...users[0], ...request.body };
@@ -162,7 +162,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const updateTracker = interceptor.patch(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
         expect(request.headers).toBeInstanceOf(HttpHeaders);
 
@@ -223,7 +223,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const updateTracker = interceptor.patch(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
         expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
@@ -276,7 +276,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch<'/users/:id'>(`/users/${users[0].id}`)
+        .patch(`/users/${users[0].id}`)
         .with({
           headers: { 'content-type': 'application/json' },
         })
@@ -348,7 +348,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch<'/users/:id'>(`/users/${users[0].id}`)
+        .patch(`/users/${users[0].id}`)
         .with({
           searchParams: { tag: 'admin' },
         })
@@ -402,7 +402,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch<'/users/:id'>(`/users/${users[0].id}`)
+        .patch(`/users/${users[0].id}`)
         .with({
           body: { name: users[0].name },
         })
@@ -486,7 +486,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
 
       genericUpdateTracker.bypass();
 
-      const specificUpdateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const specificUpdateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -538,7 +538,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       });
       await expectToThrowFetchError(updatePromise);
 
-      const updateTrackerWithoutResponse = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`);
+      const updateTrackerWithoutResponse = interceptor.patch(`/users/${users[0].id}`);
       expect(updateTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequestsWithoutResponse = updateTrackerWithoutResponse.requests();
@@ -608,7 +608,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch<'/users/:id'>(`/users/${users[0].id}`)
+        .patch(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -640,7 +640,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const errorUpdateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -687,7 +687,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .patch<'/users/:id'>(`/users/${users[0].id}`)
+        .patch(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -728,7 +728,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const errorUpdateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -792,7 +792,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const updateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -817,14 +817,14 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      let updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      let updateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
 
       interceptor.clear();
 
-      updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      updateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[1],
       });
@@ -863,7 +863,7 @@ export async function declarePatchHttpInterceptorTests({ platform }: SharedHttpI
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.patch<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const updateTracker = interceptor.patch(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -480,7 +480,7 @@ export async function declarePostHttpInterceptorTests({ platform }: SharedHttpIn
 
       genericCreationTracker.bypass();
 
-      const specificCreationTracker = interceptor.post<'/users/:id'>(`/users/${1}`).respond({
+      const specificCreationTracker = interceptor.post(`/users/${1}`).respond({
         status: 201,
         body: users[0],
       });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -57,7 +57,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const updateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -98,7 +98,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const updateTracker = interceptor.put(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<User>();
 
         const updatedUser: User = { ...users[0], ...request.body };
@@ -162,7 +162,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const updateTracker = interceptor.put(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserUpdateRequestHeaders>>();
         expect(request.headers).toBeInstanceOf(HttpHeaders);
 
@@ -223,7 +223,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond((request) => {
+      const updateTracker = interceptor.put(`/users/${users[0].id}`).respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserUpdateSearchParams>>();
         expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
@@ -276,7 +276,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put<'/users/:id'>(`/users/${users[0].id}`)
+        .put(`/users/${users[0].id}`)
         .with({
           headers: { 'content-type': 'application/json' },
         })
@@ -348,7 +348,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put<'/users/:id'>(`/users/${users[0].id}`)
+        .put(`/users/${users[0].id}`)
         .with({
           searchParams: { tag: 'admin' },
         })
@@ -402,7 +402,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put<'/users/:id'>(`/users/${users[0].id}`)
+        .put(`/users/${users[0].id}`)
         .with({
           body: { ...users[0], name: users[1].name },
         })
@@ -481,7 +481,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
 
       genericUpdateTracker.bypass();
 
-      const specificUpdateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const specificUpdateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -533,7 +533,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       });
       await expectToThrowFetchError(updatePromise);
 
-      const updateTrackerWithoutResponse = interceptor.put<'/users/:id'>(`/users/${users[0].id}`);
+      const updateTrackerWithoutResponse = interceptor.put(`/users/${users[0].id}`);
       expect(updateTrackerWithoutResponse).toBeInstanceOf(HttpRequestTracker);
 
       const updateRequestsWithoutResponse = updateTrackerWithoutResponse.requests();
@@ -603,7 +603,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put<'/users/:id'>(`/users/${users[0].id}`)
+        .put(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -635,7 +635,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const errorUpdateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -682,7 +682,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       };
     }>({ worker, baseURL }, async (interceptor) => {
       const updateTracker = interceptor
-        .put<'/users/:id'>(`/users/${users[0].id}`)
+        .put(`/users/${users[0].id}`)
         .respond({
           status: 200,
           body: users[0],
@@ -723,7 +723,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
       expectTypeOf(updateRequest.response.body).toEqualTypeOf<User>();
       expect(updateRequest.response.body).toEqual(users[1]);
 
-      const errorUpdateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const errorUpdateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 500,
         body: { message: 'Internal server error' },
       });
@@ -787,7 +787,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const updateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
@@ -812,14 +812,14 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      let updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      let updateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });
 
       interceptor.clear();
 
-      updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      updateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[1],
       });
@@ -858,7 +858,7 @@ export async function declarePutHttpInterceptorTests({ platform }: SharedHttpInt
         };
       };
     }>({ worker, baseURL }, async (interceptor) => {
-      const updateTracker = interceptor.put<'/users/:id'>(`/users/${users[0].id}`).respond({
+      const updateTracker = interceptor.put(`/users/${users[0].id}`).respond({
         status: 200,
         body: users[0],
       });

--- a/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
@@ -1,9 +1,10 @@
 import {
-  AllowAnyStringInPathParameters,
   HttpMethod,
   HttpServiceSchema,
   HttpServiceSchemaMethod,
   LiteralHttpServiceSchemaPath,
+  NonLiteralHttpServiceSchemaPath,
+  NonLiteralHttpServiceSchemaPathToLiteral,
 } from '@/http/types/schema';
 
 import { HttpRequestTracker } from '../../requestTracker/types/public';
@@ -14,12 +15,9 @@ export interface EffectiveHttpInterceptorMethodHandler<
 > {
   <Path extends LiteralHttpServiceSchemaPath<Schema, Method>>(path: Path): HttpRequestTracker<Schema, Method, Path>;
 
-  <
-    Path extends LiteralHttpServiceSchemaPath<Schema, Method> | void = void,
-    ActualPath extends Exclude<Path, void> = Exclude<Path, void>,
-  >(
-    path: AllowAnyStringInPathParameters<ActualPath>,
-  ): HttpRequestTracker<Schema, Method, ActualPath>;
+  <NonLiteralPath extends NonLiteralHttpServiceSchemaPath<Schema, Method>>(
+    path: NonLiteralPath,
+  ): HttpRequestTracker<Schema, Method, NonLiteralHttpServiceSchemaPathToLiteral<Schema, Method, NonLiteralPath>>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
@@ -4,7 +4,7 @@ import {
   HttpServiceSchemaMethod,
   LiteralHttpServiceSchemaPath,
   NonLiteralHttpServiceSchemaPath,
-  NonLiteralHttpServiceSchemaPathToLiteral,
+  InferLiteralHttpServiceSchemaPath,
 } from '@/http/types/schema';
 
 import { HttpRequestTracker } from '../../requestTracker/types/public';
@@ -17,7 +17,7 @@ export interface EffectiveHttpInterceptorMethodHandler<
 
   <NonLiteralPath extends NonLiteralHttpServiceSchemaPath<Schema, Method>>(
     path: NonLiteralPath,
-  ): HttpRequestTracker<Schema, Method, NonLiteralHttpServiceSchemaPathToLiteral<Schema, Method, NonLiteralPath>>;
+  ): HttpRequestTracker<Schema, Method, InferLiteralHttpServiceSchemaPath<Schema, Method, NonLiteralPath>>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/zimic/src/interceptor/http/requestTracker/types/utils.ts
+++ b/packages/zimic/src/interceptor/http/requestTracker/types/utils.ts
@@ -1,0 +1,6 @@
+import { HttpRequestTracker } from './public';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type HttpRequestTrackerPath<Tracker extends HttpRequestTracker<any, any, any, any>> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Tracker extends HttpRequestTracker<any, any, infer Path, any> ? Path : never;

--- a/packages/zimic/src/types/utils.ts
+++ b/packages/zimic/src/types/utils.ts
@@ -14,6 +14,8 @@ export type UnionToIntersection<Union> = (Union extends unknown ? (union: Union)
   ? IntersectedUnion
   : never;
 
+export type UnionHasMoreThanOneType<Union> = [UnionToIntersection<Union>] extends [never] ? true : false;
+
 export type Prettify<Type> = {
   [Key in keyof Type]: Type[Key];
 };

--- a/packages/zimic/vitest.config.mts
+++ b/packages/zimic/vitest.config.mts
@@ -19,6 +19,7 @@ export const defaultConfig: UserConfig = {
         branches: 100,
       },
       exclude: [
+        '**/local/**',
         '**/public/**',
         '**/.eslintrc.js',
         '**/.lintstagedrc.js',


### PR DESCRIPTION
### Features
- [#zimic] Added support to automatically infer the literal paths when using dynamic paths.
  - Previously, Zimic required an explicit declaration of the literal path whenever an interpolation was used in the path:
    ```ts
    const deleteTracker = authInterceptor.delete<'/users/:id'>(`/users/${user.id}`).respond({
      status: 204,
    });
    ```
  - Now, the literal path is automatically inferred preserving the same type safety:
    ```ts
    const deleteTracker = authInterceptor.delete(`/users/${user.id}`).respond({
      status: 204,
    });
    ```

Closes #123.