### PR TITLE
feat: no body request validation (#134)

### DIFF
--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -20,15 +20,24 @@ export interface HttpServiceResponseSchema {
   body?: HttpBody;
 }
 
-/** A schema representing the structures of HTTP responses by status code. */
-export interface HttpServiceResponseSchemaByStatusCode {
-  [statusCode: number]: HttpServiceResponseSchema;
+export namespace HttpServiceResponseSchema {
+  export interface NoBody extends Omit<HttpServiceResponseSchema, 'body'> {
+    body?: null;
+  }
 }
 
+/** A schema representing the structures of HTTP responses by status code. */
+export type HttpServiceResponseSchemaByStatusCode = {
+  [statusCode: number]: HttpServiceResponseSchema;
+} & {
+  204?: HttpServiceResponseSchema.NoBody;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 export namespace HttpServiceResponseSchemaByStatusCode {
-  export interface NoBody {
-    [statusCode: number]: Omit<HttpServiceResponseSchema, 'body'> & { body?: null };
-  }
+  export type NoBody = HttpServiceResponseSchemaByStatusCode & {
+    [statusCode: number]: HttpServiceResponseSchema.NoBody;
+  };
 }
 
 /** Extracts the status codes used in response schema by status code. */

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -196,15 +196,16 @@ class HttpInterceptorClient<
 
     if (matchedHandler) {
       const responseDeclaration = await matchedHandler.applyResponseDeclaration(parsedRequest);
-      const responseToParse = HttpInterceptorWorker.createResponseFromDeclaration(responseDeclaration);
+      const response = HttpInterceptorWorker.createResponseFromDeclaration(request, responseDeclaration);
+      const responseToReturn = response.clone();
+
       const parsedResponse = await HttpInterceptorWorker.parseRawResponse<
         Default<Schema[Path][Method]>,
         typeof responseDeclaration.status
-      >(responseToParse);
+      >(response);
 
       matchedHandler.registerInterceptedRequest(parsedRequest, parsedResponse);
 
-      const responseToReturn = HttpInterceptorWorker.createResponseFromDeclaration(responseDeclaration);
       return { response: responseToReturn };
     } else {
       return { bypass: true };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -49,7 +49,7 @@ export async function declareDeleteHttpInterceptorTests(options: RuntimeSharedHt
     Handler = options.type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
-  it('should support intercepting DELETE requests with a static response body', async () => {
+  it('should support intercepting DELETE requests with a static response', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         DELETE: {
@@ -93,7 +93,7 @@ export async function declareDeleteHttpInterceptorTests(options: RuntimeSharedHt
     });
   });
 
-  it('should support intercepting DELETE requests with a computed response body, based on the request body', async () => {
+  it('should support intercepting DELETE requests with a computed response', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         DELETE: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -49,7 +49,7 @@ export async function declareGetHttpInterceptorTests(options: RuntimeSharedHttpI
     Handler = options.type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
-  it('should support intercepting GET requests with a static response body', async () => {
+  it('should support intercepting GET requests with a static response', async () => {
     await usingHttpInterceptor<{
       '/users': {
         GET: {
@@ -93,7 +93,7 @@ export async function declareGetHttpInterceptorTests(options: RuntimeSharedHttpI
     });
   });
 
-  it('should support intercepting GET requests with a computed response body', async () => {
+  it('should support intercepting GET requests with a computed response', async () => {
     await usingHttpInterceptor<{
       '/users': {
         GET: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -41,12 +41,15 @@ export function declareOptionsHttpInterceptorTests(options: RuntimeSharedHttpInt
     numberOfRequestsIncludingPrefetch = platform === 'browser' && options.type === 'remote' ? 2 : 1;
   });
 
-  it('should support intercepting OPTIONS requests with a static response body', async () => {
+  it('should support intercepting OPTIONS requests with a static response', async () => {
     await usingHttpInterceptor<{
       '/filters': {
         OPTIONS: {
           response: {
-            200: { headers: AccessControlHeaders };
+            200: {
+              headers: AccessControlHeaders;
+              body: string;
+            };
           };
         };
       };
@@ -55,6 +58,7 @@ export function declareOptionsHttpInterceptorTests(options: RuntimeSharedHttpInt
         interceptor.options('/filters').respond({
           status: 200,
           headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+          body: 'ok',
         }),
         interceptor,
       );
@@ -77,17 +81,20 @@ export function declareOptionsHttpInterceptorTests(options: RuntimeSharedHttpInt
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<200>();
       expect(optionsRequest.response.status).toEqual(200);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
-      expect(optionsRequest.response.body).toBe(null);
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<string>();
+      expect(optionsRequest.response.body).toBe('ok');
     });
   });
 
-  it('should support intercepting OPTIONS requests with a computed response body', async () => {
+  it('should support intercepting OPTIONS requests with a computed response', async () => {
     await usingHttpInterceptor<{
       '/filters': {
         OPTIONS: {
           response: {
-            200: { headers: AccessControlHeaders };
+            200: {
+              headers: AccessControlHeaders;
+              body: string;
+            };
           };
         };
       };
@@ -99,6 +106,7 @@ export function declareOptionsHttpInterceptorTests(options: RuntimeSharedHttpInt
           return {
             status: 200,
             headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+            body: 'ok',
           };
         }),
         interceptor,
@@ -126,8 +134,8 @@ export function declareOptionsHttpInterceptorTests(options: RuntimeSharedHttpInt
       expectTypeOf(optionsRequest.response.status).toEqualTypeOf<200>();
       expect(optionsRequest.response.status).toEqual(200);
 
-      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<null>();
-      expect(optionsRequest.response.body).toBe(null);
+      expectTypeOf(optionsRequest.response.body).toEqualTypeOf<string>();
+      expect(optionsRequest.response.body).toBe('ok');
     });
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -49,7 +49,7 @@ export async function declarePatchHttpInterceptorTests(options: RuntimeSharedHtt
     Handler = options.type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
-  it('should support intercepting PATCH requests with a static response body', async () => {
+  it('should support intercepting PATCH requests with a static response', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         PATCH: {
@@ -93,7 +93,7 @@ export async function declarePatchHttpInterceptorTests(options: RuntimeSharedHtt
     });
   });
 
-  it('should support intercepting PATCH requests with a computed response body, based on the request body', async () => {
+  it('should support intercepting PATCH requests with a computed response', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         PATCH: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -51,7 +51,7 @@ export async function declarePostHttpInterceptorTests(options: RuntimeSharedHttp
     Handler = options.type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
-  it('should support intercepting POST requests with a static response body', async () => {
+  it('should support intercepting POST requests with a static response', async () => {
     await usingHttpInterceptor<{
       '/users': {
         POST: {
@@ -95,7 +95,7 @@ export async function declarePostHttpInterceptorTests(options: RuntimeSharedHttp
     });
   });
 
-  it('should support intercepting POST requests with a computed response body, based on the request body', async () => {
+  it('should support intercepting POST requests with a computed response', async () => {
     await usingHttpInterceptor<{
       '/users': {
         POST: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -49,7 +49,7 @@ export async function declarePutHttpInterceptorTests(options: RuntimeSharedHttpI
     Handler = options.type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
-  it('should support intercepting PUT requests with a static response body', async () => {
+  it('should support intercepting PUT requests with a static response', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         PUT: {
@@ -93,7 +93,7 @@ export async function declarePutHttpInterceptorTests(options: RuntimeSharedHttpI
     });
   });
 
-  it('should support intercepting PUT requests with a computed response body, based on the request body', async () => {
+  it('should support intercepting PUT requests with a computed response', async () => {
     await usingHttpInterceptor<{
       '/users/:id': {
         PUT: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -222,7 +222,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
     });
   });
 
-  it('should not allow declaring response bodies for methods that do not support them', () => {
+  it('should not allow declaring request bodies for methods that do not support them', () => {
     // @ts-expect-error GET methods do not support request bodies
     createHttpInterceptor<{ '/users': { GET: { request: { body: User } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { GET: { request: { body: null } } } }>({ type, baseURL });
@@ -262,93 +262,77 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
     createHttpInterceptor<{ '/users': { DELETE: { request: {} } } }>({ type, baseURL });
   });
 
-  it('should not allow declaring response bodies for methods that do not support them', () => {
+  it('should not allow declaring response bodies for methods or statuses that do not support them', () => {
     // @ts-expect-error HEAD methods do not support request bodies
-    createHttpInterceptor<{ '/users': { HEAD: { response: { 200: { body: User } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { HEAD: { response: { 200: { body: null } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { HEAD: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 200: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 200: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { HEAD: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { HEAD: { response: { 204: {} } } } }>({ type, baseURL });
 
     createHttpInterceptor<{ '/users': { GET: { response: { 200: { body: User } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { GET: { response: { 200: { body: null } } } } }>({ type, baseURL });
-    createHttpInterceptor<{ '/users': { GET: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { GET: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { GET: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { GET: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { GET: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { GET: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { GET: { response: { 204: {} } } } }>({ type, baseURL });
 
-    createHttpInterceptor<{ '/users': { POST: { response: { 200: { body: User } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { POST: { response: { 200: { body: null } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { POST: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { POST: { response: { 200: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { POST: { response: { 200: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { POST: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { POST: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { POST: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { POST: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { POST: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { POST: { response: { 204: {} } } } }>({ type, baseURL });
 
     createHttpInterceptor<{ '/users': { PUT: { response: { 200: { body: User } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { PUT: { response: { 200: { body: null } } } } }>({ type, baseURL });
-    createHttpInterceptor<{ '/users': { PUT: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { PUT: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { PUT: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { PUT: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PUT: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PUT: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PUT: { response: { 204: {} } } } }>({ type, baseURL });
 
-    createHttpInterceptor<{ '/users': { PATCH: { response: { 200: { body: User } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { PATCH: { response: { 200: { body: null } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { PATCH: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 200: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 200: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { PATCH: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { PATCH: { response: { 204: {} } } } }>({ type, baseURL });
 
-    createHttpInterceptor<{ '/users': { DELETE: { response: { 200: { body: User } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { DELETE: { response: { 200: { body: null } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { DELETE: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 200: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 200: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { DELETE: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { DELETE: { response: { 204: {} } } } }>({ type, baseURL });
 
-    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: { body: User } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: { body: null } } } } }>({
-      type,
-      baseURL,
-    });
-    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: { body: undefined } } } } }>({
-      type,
-      baseURL,
-    });
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: { body: undefined } } } } }>({ type, baseURL });
     createHttpInterceptor<{ '/users': { OPTIONS: { response: { 200: {} } } } }>({ type, baseURL });
+    // @ts-expect-error 204 responses do not support request bodies
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 204: { body: User } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 204: { body: null } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 204: { body: undefined } } } } }>({ type, baseURL });
+    createHttpInterceptor<{ '/users': { OPTIONS: { response: { 204: {} } } } }>({ type, baseURL });
   });
 
   describe('Dynamic paths', () => {

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -98,11 +98,15 @@ abstract class HttpInterceptorWorker {
       body?: HttpBody;
     },
     HeadersSchema extends HttpHeadersSchema,
-  >(responseDeclaration: Declaration) {
-    const response = MSWHttpResponse.json(responseDeclaration.body, {
-      headers: new HttpHeaders(responseDeclaration.headers),
-      status: responseDeclaration.status,
-    });
+  >(request: HttpRequest, responseDeclaration: Declaration) {
+    const headers = new HttpHeaders(responseDeclaration.headers);
+    const status = responseDeclaration.status;
+
+    const canHaveBody = request.method !== 'HEAD' && status !== 204;
+
+    const response = canHaveBody
+      ? MSWHttpResponse.json(responseDeclaration.body, { headers, status })
+      : new Response(null, { headers, status });
 
     return response as typeof response & HttpResponse<Declaration['body'], Declaration['status'], HeadersSchema>;
   }


### PR DESCRIPTION
### Features
- [#zimic] Added an additional validation to interceptor schemas, ensuring that 204 responses do not contain a body.
- [#zimic] Implemented a check when creating responses to ensure that HEAD requests or 204 responses always have an empty body, as required by the spec.

Closes #134.
