### PR TITLE
fix: multiple dynamic parameters (#137)

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
@@ -1,5 +1,5 @@
 import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
-import { createExtendedURL, excludeDynamicParams } from '@/utils/fetch';
+import { createExtendedURL, excludeNonPathParams } from '@/utils/fetch';
 
 import LocalHttpRequestHandler from '../requestHandler/LocalHttpRequestHandler';
 import HttpInterceptorClient, { SUPPORTED_BASE_URL_PROTOCOLS } from './HttpInterceptorClient';
@@ -19,7 +19,7 @@ class LocalHttpInterceptor<Schema extends HttpServiceSchema> implements PublicLo
     const baseURL = createExtendedURL(options.baseURL, {
       protocols: SUPPORTED_BASE_URL_PROTOCOLS,
     });
-    excludeDynamicParams(baseURL);
+    excludeNonPathParams(baseURL);
 
     const worker = this.store.getOrCreateLocalWorker({});
 

--- a/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
@@ -1,5 +1,5 @@
 import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
-import { createExtendedURL, excludeDynamicParams } from '@/utils/fetch';
+import { createExtendedURL, excludeNonPathParams } from '@/utils/fetch';
 
 import RemoteHttpRequestHandler from '../requestHandler/RemoteHttpRequestHandler';
 import HttpInterceptorClient, { SUPPORTED_BASE_URL_PROTOCOLS } from './HttpInterceptorClient';
@@ -19,12 +19,12 @@ class RemoteHttpInterceptor<Schema extends HttpServiceSchema> implements PublicR
     const baseURL = createExtendedURL(options.baseURL, {
       protocols: SUPPORTED_BASE_URL_PROTOCOLS,
     });
-    excludeDynamicParams(baseURL);
+    excludeNonPathParams(baseURL);
 
     const serverURL = createExtendedURL(baseURL.origin, {
       protocols: SUPPORTED_BASE_URL_PROTOCOLS,
     });
-    excludeDynamicParams(serverURL);
+    excludeNonPathParams(serverURL);
 
     const worker = this.store.getOrCreateRemoteWorker({ serverURL });
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -8,7 +8,7 @@ import {
 
 import { HttpBody } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
-import { excludeDynamicParams } from '@/utils/fetch';
+import { ensureUniqueDynamicPathParams, excludeDynamicParams } from '@/utils/fetch';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatform from '../interceptor/errors/UnknownHttpInterceptorPlatform';
@@ -146,6 +146,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     const lowercaseMethod = method.toLowerCase<typeof method>();
 
     const url = excludeDynamicParams(new URL(rawURL)).toString();
+    ensureUniqueDynamicPathParams(url);
 
     const httpHandler = http[lowercaseMethod](url, async (context) => {
       const result = await createResponse({

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -8,7 +8,7 @@ import {
 
 import { HttpBody } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
-import { ensureUniqueDynamicPathParams, excludeDynamicParams } from '@/utils/fetch';
+import { ensureUniquePathParams, excludeNonPathParams } from '@/utils/fetch';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatform from '../interceptor/errors/UnknownHttpInterceptorPlatform';
@@ -145,8 +145,8 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     const internalWorker = this.internalWorkerOrThrow();
     const lowercaseMethod = method.toLowerCase<typeof method>();
 
-    const url = excludeDynamicParams(new URL(rawURL)).toString();
-    ensureUniqueDynamicPathParams(url);
+    const url = excludeNonPathParams(new URL(rawURL)).toString();
+    ensureUniquePathParams(url);
 
     const httpHandler = http[lowercaseMethod](url, async (context) => {
       const result = await createResponse({

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -2,7 +2,13 @@ import { HttpResponse } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, ServerWebSocketSchema } from '@/server/types/schema';
 import { getCrypto, IsomorphicCrypto } from '@/utils/crypto';
-import { excludeDynamicParams, deserializeRequest, serializeResponse, ExtendedURL } from '@/utils/fetch';
+import {
+  excludeDynamicParams,
+  deserializeRequest,
+  serializeResponse,
+  ExtendedURL,
+  ensureUniqueDynamicPathParams,
+} from '@/utils/fetch';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketClient from '@/webSocket/WebSocketClient';
 
@@ -118,6 +124,7 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
 
     const crypto = await this.crypto();
     const url = excludeDynamicParams(new URL(rawURL)).toString();
+    ensureUniqueDynamicPathParams(url);
 
     const handler: HttpHandler = {
       id: crypto.randomUUID(),

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -3,11 +3,11 @@ import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, ServerWebSocketSchema } from '@/server/types/schema';
 import { getCrypto, IsomorphicCrypto } from '@/utils/crypto';
 import {
-  excludeDynamicParams,
+  excludeNonPathParams,
   deserializeRequest,
   serializeResponse,
   ExtendedURL,
-  ensureUniqueDynamicPathParams,
+  ensureUniquePathParams,
 } from '@/utils/fetch';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketClient from '@/webSocket/WebSocketClient';
@@ -123,8 +123,8 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
     }
 
     const crypto = await this.crypto();
-    const url = excludeDynamicParams(new URL(rawURL)).toString();
-    ensureUniqueDynamicPathParams(url);
+    const url = excludeNonPathParams(new URL(rawURL)).toString();
+    ensureUniquePathParams(url);
 
     const handler: HttpHandler = {
       id: crypto.randomUUID(),

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/default.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import NotStartedHttpInterceptorError from '@/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError';
 import { createExtendedURL } from '@/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptorWorker } from '@tests/utils/interceptors';
 
-import NotStartedHttpInterceptorError from '../../../interceptor/errors/NotStartedHttpInterceptorError';
 import HttpInterceptorWorker from '../../HttpInterceptorWorker';
 import LocalHttpInterceptorWorker from '../../LocalHttpInterceptorWorker';
 import RemoteHttpInterceptorWorker from '../../RemoteHttpInterceptorWorker';
@@ -30,7 +30,7 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
       return createInternalHttpInterceptor<{}>({ type: workerOptions.type, baseURL });
     }
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       if (defaultWorkerOptions.type === 'remote') {
         await startServer?.();
       }
@@ -43,7 +43,7 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
           : { ...defaultWorkerOptions, serverURL: createExtendedURL(baseURL.origin) };
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       if (defaultWorkerOptions.type === 'remote') {
         await stopServer?.();
       }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
@@ -4,7 +4,7 @@ import HttpHeaders from '@/http/headers/HttpHeaders';
 import { HTTP_METHODS } from '@/http/types/schema';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/server/constants';
 import { PossiblePromise } from '@/types/utils';
-import { DuplicatePathParameterError, createExtendedURL, fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { DuplicatedPathParamError, createExtendedURL, fetchWithTimeout, joinURL } from '@/utils/fetch';
 import { waitForDelay } from '@/utils/time';
 import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptorWorker } from '@tests/utils/interceptors';
@@ -247,7 +247,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         { use: '/some/:other/path/:other', duplicatedParameter: 'other' },
         { use: '/some/path/:other/:other', duplicatedParameter: 'other' },
       ])(
-        `should throw an error if trying to use a ${method} url with duplicate dynamic path params (use $use; fetch $fetch)`,
+        `should throw an error if trying to use a ${method} url with duplicate dynamic path params (use $use)`,
         async (paths) => {
           const useURL = joinURL(baseURL, paths.use);
 
@@ -256,7 +256,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
             await expect(async () => {
               await worker.use(interceptor.client(), method, useURL, spiedRequestHandler);
-            }).rejects.toThrowError(new DuplicatePathParameterError(useURL, paths.duplicatedParameter));
+            }).rejects.toThrowError(new DuplicatedPathParamError(useURL, paths.duplicatedParameter));
 
             expect(spiedRequestHandler).not.toHaveBeenCalled();
           });

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import HttpHeaders from '@/http/headers/HttpHeaders';
 import { HTTP_METHODS } from '@/http/types/schema';
+import NotStartedHttpInterceptorError from '@/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/server/constants';
 import { PossiblePromise } from '@/types/utils';
 import { DuplicatedPathParamError, createExtendedURL, fetchWithTimeout, joinURL } from '@/utils/fetch';
@@ -9,7 +10,6 @@ import { waitForDelay } from '@/utils/time';
 import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptorWorker } from '@tests/utils/interceptors';
 
-import NotStartedHttpInterceptorError from '../../../interceptor/errors/NotStartedHttpInterceptorError';
 import {
   HttpInterceptorWorkerOptions,
   LocalHttpInterceptorWorkerOptions,
@@ -38,7 +38,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
       return createInternalHttpInterceptor<{}>({ type: defaultWorkerOptions.type, baseURL });
     }
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       if (defaultWorkerOptions.type === 'remote') {
         await startServer?.();
       }
@@ -51,7 +51,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
           : { ...defaultWorkerOptions, serverURL: createExtendedURL(baseURL.origin) };
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       if (defaultWorkerOptions.type === 'remote') {
         await stopServer?.();
       }

--- a/packages/zimic/src/server/Server.ts
+++ b/packages/zimic/src/server/Server.ts
@@ -3,7 +3,7 @@ import { createServer, Server as HttpServer, IncomingMessage, ServerResponse } f
 import type { WebSocket as Socket } from 'isomorphic-ws';
 
 import { HttpMethod } from '@/http/types/schema';
-import { createRegexFromURL, excludeDynamicParams, deserializeResponse, serializeRequest } from '@/utils/fetch';
+import { createRegexFromURL, excludeNonPathParams, deserializeResponse, serializeRequest } from '@/utils/fetch';
 import { getHttpServerPort, startHttpServer, stopHttpServer } from '@/utils/http';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketServer from '@/webSocket/WebSocketServer';
@@ -153,7 +153,7 @@ class Server implements PublicServer {
   private registerHttpHandlerGroup({ id, url: rawURL, method }: HttpHandlerCommit, socket: Socket) {
     const handlerGroups = this.httpHandlerGroups[method];
 
-    const url = excludeDynamicParams(new URL(rawURL)).toString();
+    const url = excludeNonPathParams(new URL(rawURL)).toString();
 
     handlerGroups.push({
       id,
@@ -234,7 +234,7 @@ class Server implements PublicServer {
     const webSocketServer = this.webSocketServer();
     const handlerGroup = this.httpHandlerGroups[request.method as HttpMethod];
 
-    const url = excludeDynamicParams(new URL(request.url)).toString();
+    const url = excludeNonPathParams(new URL(request.url)).toString();
     const serializedRequest = await serializeRequest(request);
 
     for (let index = handlerGroup.length - 1; index >= 0; index--) {

--- a/packages/zimic/src/utils/fetch.ts
+++ b/packages/zimic/src/utils/fetch.ts
@@ -37,7 +37,7 @@ export function excludeDynamicParams(url: URL) {
 }
 
 export function createRegexFromURL(url: string) {
-  const urlWithReplacedPathParams = url.replace(/\/:([^/]+)/, '/(?<$1>[^/]+)').replace(/(\/+)$/, '(?:$1)?');
+  const urlWithReplacedPathParams = url.replace(/\/:([^/]+)/g, '/(?<$1>[^/]+)').replace(/(\/+)$/, '(?:$1)?');
   return new RegExp(`^${urlWithReplacedPathParams}$`);
 }
 

--- a/packages/zimic/src/utils/fetch.ts
+++ b/packages/zimic/src/utils/fetch.ts
@@ -28,7 +28,7 @@ export function createExtendedURL(
   return url;
 }
 
-export function excludeDynamicParams(url: URL) {
+export function excludeNonPathParams(url: URL) {
   url.hash = '';
   url.search = '';
   url.username = '';
@@ -36,36 +36,34 @@ export function excludeDynamicParams(url: URL) {
   return url;
 }
 
-export class DuplicatePathParameterError extends Error {
+export class DuplicatedPathParamError extends Error {
   constructor(url: string, paramName: string) {
     super(
       `The path parameter '${paramName}' appears more than once in the URL '${url}'. This is not supported. Please` +
         ' make sure that each parameter is unique.',
     );
-    this.name = 'DuplicatePathParameterError';
+    this.name = 'DuplicatedPathParamError';
   }
 }
 
-const URL_DYNAMIC_PATH_PARAM_REGEX = /\/:([^/]+)/g;
+const URL_PATH_PARAM_REGEX = /\/:([^/]+)/g;
 
-export function ensureUniqueDynamicPathParams(url: string) {
-  const matches = url.matchAll(URL_DYNAMIC_PATH_PARAM_REGEX);
+export function ensureUniquePathParams(url: string) {
+  const matches = url.matchAll(URL_PATH_PARAM_REGEX);
 
   const uniqueParamNames = new Set<string>();
 
   for (const match of matches) {
     const paramName = match[1];
     if (uniqueParamNames.has(paramName)) {
-      throw new DuplicatePathParameterError(url, paramName);
+      throw new DuplicatedPathParamError(url, paramName);
     }
     uniqueParamNames.add(paramName);
   }
 }
 
 export function createRegexFromURL(url: string) {
-  const urlWithReplacedPathParams = url
-    .replace(URL_DYNAMIC_PATH_PARAM_REGEX, '/(?<$1>[^/]+)')
-    .replace(/(\/+)$/, '(?:$1)?');
+  const urlWithReplacedPathParams = url.replace(URL_PATH_PARAM_REGEX, '/(?<$1>[^/]+)').replace(/(\/+)$/, '(?:$1)?');
   return new RegExp(`^${urlWithReplacedPathParams}$`);
 }
 


### PR DESCRIPTION
### Fixes
- [#zimic] Correctly identified URLs containing more than one path param. Also added tests to check common URL configurations.
- [#zimic] Added an error `DuplicatedPathParamError`, which is now thrown when a duplicate path param name is used. Previously, there was no error in the local mode, but the server on remote mode could not parse the url regex.

Closes #137.