### PR TITLE
refactor: split fetch and url utilities

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -7,7 +7,7 @@ import {
   HttpServiceSchemaPath,
 } from '@/http/types/schema';
 import { Default, PossiblePromise } from '@/types/utils';
-import { ExtendedURL, joinURL } from '@/utils/fetch';
+import { joinURL, ExtendedURL } from '@/utils/urls';
 
 import HttpInterceptorWorker from '../interceptorWorker/HttpInterceptorWorker';
 import LocalHttpInterceptorWorker from '../interceptorWorker/LocalHttpInterceptorWorker';

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorStore.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorStore.ts
@@ -1,4 +1,4 @@
-import { ExtendedURL } from '@/utils/fetch';
+import { ExtendedURL } from '@/utils/urls';
 
 import { createHttpInterceptorWorker } from '../interceptorWorker/factory';
 import LocalHttpInterceptorWorker from '../interceptorWorker/LocalHttpInterceptorWorker';

--- a/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
@@ -1,5 +1,5 @@
 import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
-import { createExtendedURL, excludeNonPathParams } from '@/utils/fetch';
+import { createExtendedURL, excludeNonPathParams } from '@/utils/urls';
 
 import LocalHttpRequestHandler from '../requestHandler/LocalHttpRequestHandler';
 import HttpInterceptorClient, { SUPPORTED_BASE_URL_PROTOCOLS } from './HttpInterceptorClient';

--- a/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
@@ -1,5 +1,5 @@
 import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
-import { createExtendedURL, excludeNonPathParams } from '@/utils/fetch';
+import { createExtendedURL, excludeNonPathParams } from '@/utils/urls';
 
 import RemoteHttpRequestHandler from '../requestHandler/RemoteHttpRequestHandler';
 import HttpInterceptorClient, { SUPPORTED_BASE_URL_PROTOCOLS } from './HttpInterceptorClient';

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/baseURLs.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/baseURLs.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
-import { ExtendedURL, joinURL } from '@/utils/fetch';
+import { joinURL, ExtendedURL } from '@/utils/urls';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { SUPPORTED_BASE_URL_PROTOCOLS } from '../../HttpInterceptorClient';

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/default.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, expect, it } from 'vitest';
 
-import { ExtendedURL, createExtendedURL } from '@/utils/fetch';
+import { ExtendedURL, createExtendedURL } from '@/utils/urls';
 import { getSingletonWorkerByType, usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import NotStartedHttpInterceptorError from '../../errors/NotStartedHttpInterceptorError';

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/interceptorTests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/interceptorTests.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { HttpMethod } from '@/http/types/schema';
 import { PossiblePromise } from '@/types/utils';
-import { ExtendedURL } from '@/utils/fetch';
+import { ExtendedURL } from '@/utils/urls';
 import { createInternalHttpInterceptor } from '@tests/utils/interceptors';
 
 import UnknownHttpInterceptorTypeError from '../../errors/UnknownHttpInterceptorTypeError';

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/delete.ts
@@ -8,7 +8,8 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';
 import { getCrypto } from '@/utils/crypto';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/get.ts
@@ -8,7 +8,8 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';
 import { getCrypto } from '@/utils/crypto';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/head.ts
@@ -6,7 +6,8 @@ import { HttpSchema } from '@/http/types/schema';
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/options.ts
@@ -8,7 +8,8 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { DEFAULT_ACCESS_CONTROL_HEADERS, AccessControlHeaders } from '@/server/constants';
 import { JSONValue } from '@/types/json';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/patch.ts
@@ -8,7 +8,8 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';
 import { getCrypto } from '@/utils/crypto';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/post.ts
@@ -8,7 +8,8 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';
 import { getCrypto } from '@/utils/crypto';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/methods/put.ts
@@ -8,7 +8,8 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';
 import { getCrypto } from '@/utils/crypto';
-import { fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { expectFetchError } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptor } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/types.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/types.ts
@@ -1,5 +1,5 @@
 import { PossiblePromise } from '@/types/utils';
-import { ExtendedURL } from '@/utils/fetch';
+import { ExtendedURL } from '@/utils/urls';
 
 import { HttpInterceptorPlatform, HttpInterceptorType, HttpInterceptorOptions } from '../../types/options';
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -8,7 +8,7 @@ import {
 
 import { HttpBody } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
-import { ensureUniquePathParams, excludeNonPathParams } from '@/utils/fetch';
+import { excludeNonPathParams, ensureUniquePathParams } from '@/utils/urls';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatform from '../interceptor/errors/UnknownHttpInterceptorPlatform';

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -2,13 +2,8 @@ import { HttpResponse } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, ServerWebSocketSchema } from '@/server/types/schema';
 import { getCrypto, IsomorphicCrypto } from '@/utils/crypto';
-import {
-  excludeNonPathParams,
-  deserializeRequest,
-  serializeResponse,
-  ExtendedURL,
-  ensureUniquePathParams,
-} from '@/utils/fetch';
+import { deserializeRequest, serializeResponse } from '@/utils/fetch';
+import { excludeNonPathParams, ExtendedURL, ensureUniquePathParams } from '@/utils/urls';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketClient from '@/webSocket/WebSocketClient';
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/default.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import NotStartedHttpInterceptorError from '@/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError';
-import { createExtendedURL } from '@/utils/fetch';
+import { createExtendedURL } from '@/utils/urls';
 import { createInternalHttpInterceptor, usingHttpInterceptorWorker } from '@tests/utils/interceptors';
 
 import HttpInterceptorWorker from '../../HttpInterceptorWorker';

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
@@ -5,8 +5,9 @@ import { HTTP_METHODS } from '@/http/types/schema';
 import NotStartedHttpInterceptorError from '@/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/server/constants';
 import { PossiblePromise } from '@/types/utils';
-import { DuplicatedPathParamError, createExtendedURL, fetchWithTimeout, joinURL } from '@/utils/fetch';
+import { fetchWithTimeout } from '@/utils/fetch';
 import { waitForDelay } from '@/utils/time';
+import { joinURL, DuplicatedPathParamError, createExtendedURL } from '@/utils/urls';
 import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { createInternalHttpInterceptor, usingHttpInterceptorWorker } from '@tests/utils/interceptors';
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/types.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/types.ts
@@ -1,6 +1,6 @@
 import { HttpInterceptorPlatform, HttpInterceptorType } from '@/interceptor/http/interceptor/types/options';
 import { PossiblePromise } from '@/types/utils';
-import { ExtendedURL } from '@/utils/fetch';
+import { ExtendedURL } from '@/utils/urls';
 
 export interface SharedHttpInterceptorWorkerTestOptions {
   platform: HttpInterceptorPlatform;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/options.ts
@@ -1,4 +1,4 @@
-import { ExtendedURL } from '@/utils/fetch';
+import { ExtendedURL } from '@/utils/urls';
 
 export interface LocalHttpInterceptorWorkerOptions {
   type: 'local';

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
@@ -8,8 +8,8 @@ import { HttpInterceptorType } from '@/interceptor/http/interceptor/types/option
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
 import LocalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker';
-import { joinURL } from '@/utils/fetch';
 import { waitForDelay } from '@/utils/time';
+import { joinURL } from '@/utils/urls';
 import { createInternalHttpInterceptor } from '@tests/utils/interceptors';
 
 import NoResponseDefinitionError from '../../errors/NoResponseDefinitionError';

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
@@ -7,7 +7,7 @@ import LocalHttpInterceptor from '@/interceptor/http/interceptor/LocalHttpInterc
 import RemoteHttpInterceptor from '@/interceptor/http/interceptor/RemoteHttpInterceptor';
 import { HttpInterceptorType } from '@/interceptor/http/interceptor/types/options';
 import HttpInterceptorWorker from '@/interceptor/http/interceptorWorker/HttpInterceptorWorker';
-import { joinURL } from '@/utils/fetch';
+import { joinURL } from '@/utils/urls';
 import { createInternalHttpInterceptor } from '@tests/utils/interceptors';
 
 import LocalHttpRequestHandler from '../../LocalHttpRequestHandler';

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/types.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/types.ts
@@ -1,7 +1,7 @@
 import { HttpSchema } from '@/http/types/schema';
 import { HttpInterceptorPlatform, HttpInterceptorType } from '@/interceptor/http/interceptor/types/options';
 import { PossiblePromise } from '@/types/utils';
-import { ExtendedURL } from '@/utils/fetch';
+import { ExtendedURL } from '@/utils/urls';
 
 export interface SharedHttpRequestHandlerTestOptions {
   platform: HttpInterceptorPlatform;

--- a/packages/zimic/src/server/Server.ts
+++ b/packages/zimic/src/server/Server.ts
@@ -3,8 +3,9 @@ import { createServer, Server as HttpServer, IncomingMessage, ServerResponse } f
 import type { WebSocket as Socket } from 'isomorphic-ws';
 
 import { HttpMethod } from '@/http/types/schema';
-import { createRegexFromURL, excludeNonPathParams, deserializeResponse, serializeRequest } from '@/utils/fetch';
+import { deserializeResponse, serializeRequest } from '@/utils/fetch';
 import { getHttpServerPort, startHttpServer, stopHttpServer } from '@/utils/http';
+import { createRegexFromURL, excludeNonPathParams } from '@/utils/urls';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketServer from '@/webSocket/WebSocketServer';
 

--- a/packages/zimic/src/utils/fetch.ts
+++ b/packages/zimic/src/utils/fetch.ts
@@ -1,71 +1,4 @@
-import { JSONValue } from '..';
-
-export interface ExtendedURL extends URL {
-  raw: string;
-}
-
-export function createExtendedURL(
-  rawURL: string | URL,
-  options: {
-    protocols?: string[];
-  } = {},
-) {
-  const url = new URL(rawURL) as ExtendedURL;
-
-  const protocol = url.protocol.replace(/:$/, '');
-
-  if (options.protocols && !options.protocols.includes(protocol)) {
-    throw new TypeError(`Expected URL with protocol (${options.protocols.join('|')}), but got '${protocol}'`);
-  }
-
-  Object.defineProperty(url, 'raw', {
-    value: rawURL.toString(),
-    writable: false,
-    enumerable: true,
-    configurable: false,
-  });
-
-  return url;
-}
-
-export function excludeNonPathParams(url: URL) {
-  url.hash = '';
-  url.search = '';
-  url.username = '';
-  url.password = '';
-  return url;
-}
-
-export class DuplicatedPathParamError extends Error {
-  constructor(url: string, paramName: string) {
-    super(
-      `The path parameter '${paramName}' appears more than once in the URL '${url}'. This is not supported. Please` +
-        ' make sure that each parameter is unique.',
-    );
-    this.name = 'DuplicatedPathParamError';
-  }
-}
-
-const URL_PATH_PARAM_REGEX = /\/:([^/]+)/g;
-
-export function ensureUniquePathParams(url: string) {
-  const matches = url.matchAll(URL_PATH_PARAM_REGEX);
-
-  const uniqueParamNames = new Set<string>();
-
-  for (const match of matches) {
-    const paramName = match[1];
-    if (uniqueParamNames.has(paramName)) {
-      throw new DuplicatedPathParamError(url, paramName);
-    }
-    uniqueParamNames.add(paramName);
-  }
-}
-
-export function createRegexFromURL(url: string) {
-  const urlWithReplacedPathParams = url.replace(URL_PATH_PARAM_REGEX, '/(?<$1>[^/]+)').replace(/(\/+)$/, '(?:$1)?');
-  return new RegExp(`^${urlWithReplacedPathParams}$`);
-}
+import { JSONValue } from '@/types/json';
 
 export async function fetchWithTimeout(url: URL | RequestInfo, options: RequestInit & { timeout: number }) {
   const abort = new AbortController();
@@ -80,17 +13,6 @@ export async function fetchWithTimeout(url: URL | RequestInfo, options: RequestI
   } finally {
     clearTimeout(timeout);
   }
-}
-
-export function joinURL(...parts: (string | URL)[]) {
-  return parts
-    .map((part, index) => {
-      const partAsString = part.toString();
-      const isLastPath = index === parts.length - 1;
-      return isLastPath ? partAsString.replace(/^[/ ]+/, '') : partAsString.replace(/^[/ ]+|[/ ]+$/, '');
-    })
-    .filter((part) => part.length > 0)
-    .join('/');
 }
 
 export type SerializedHttpRequest = JSONValue<{

--- a/packages/zimic/src/utils/urls.ts
+++ b/packages/zimic/src/utils/urls.ts
@@ -1,0 +1,76 @@
+export interface ExtendedURL extends URL {
+  raw: string;
+}
+
+export function createExtendedURL(
+  rawURL: string | URL,
+  options: {
+    protocols?: string[];
+  } = {},
+) {
+  const url = new URL(rawURL) as ExtendedURL;
+
+  const protocol = url.protocol.replace(/:$/, '');
+
+  if (options.protocols && !options.protocols.includes(protocol)) {
+    throw new TypeError(`Expected URL with protocol (${options.protocols.join('|')}), but got '${protocol}'`);
+  }
+
+  Object.defineProperty(url, 'raw', {
+    value: rawURL.toString(),
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  });
+
+  return url;
+}
+
+export function excludeNonPathParams(url: URL) {
+  url.hash = '';
+  url.search = '';
+  url.username = '';
+  url.password = '';
+  return url;
+}
+
+export class DuplicatedPathParamError extends Error {
+  constructor(url: string, paramName: string) {
+    super(
+      `The path parameter '${paramName}' appears more than once in the URL '${url}'. This is not supported. Please` +
+        ' make sure that each parameter is unique.',
+    );
+    this.name = 'DuplicatedPathParamError';
+  }
+}
+const URL_PATH_PARAM_REGEX = /\/:([^/]+)/g;
+
+export function ensureUniquePathParams(url: string) {
+  const matches = url.matchAll(URL_PATH_PARAM_REGEX);
+
+  const uniqueParamNames = new Set<string>();
+
+  for (const match of matches) {
+    const paramName = match[1];
+    if (uniqueParamNames.has(paramName)) {
+      throw new DuplicatedPathParamError(url, paramName);
+    }
+    uniqueParamNames.add(paramName);
+  }
+}
+
+export function createRegexFromURL(url: string) {
+  const urlWithReplacedPathParams = url.replace(URL_PATH_PARAM_REGEX, '/(?<$1>[^/]+)').replace(/(\/+)$/, '(?:$1)?');
+  return new RegExp(`^${urlWithReplacedPathParams}$`);
+}
+
+export function joinURL(...parts: (string | URL)[]) {
+  return parts
+    .map((part, index) => {
+      const partAsString = part.toString();
+      const isLastPath = index === parts.length - 1;
+      return isLastPath ? partAsString.replace(/^[/ ]+/, '') : partAsString.replace(/^[/ ]+|[/ ]+$/, '');
+    })
+    .filter((part) => part.length > 0)
+    .join('/');
+}

--- a/packages/zimic/src/webSocket/WebSocketClient.ts
+++ b/packages/zimic/src/webSocket/WebSocketClient.ts
@@ -1,6 +1,6 @@
 import ClientSocket from 'isomorphic-ws';
 
-import { createExtendedURL } from '@/utils/fetch';
+import { createExtendedURL } from '@/utils/urls';
 
 import { WebSocket } from './types';
 import WebSocketHandler from './WebSocketHandler';

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -21,7 +21,7 @@ import {
 import Server from '@/server/Server';
 import { PossiblePromise } from '@/types/utils';
 import { getCrypto } from '@/utils/crypto';
-import { createExtendedURL, ExtendedURL, joinURL } from '@/utils/fetch';
+import { joinURL, createExtendedURL, ExtendedURL } from '@/utils/urls';
 import { GLOBAL_SETUP_SERVER_HOSTNAME, GLOBAL_SETUP_SERVER_PORT } from '@tests/globalSetup/serverOnBrowser';
 
 export async function getBrowserBaseURL(workerType: HttpInterceptorType) {


### PR DESCRIPTION
### Refactoring
- [#zimic] Split fetch and URL utilities into dedicated files, improving readability.
