### PR TITLE
refactor!: http namespace (#147)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -30,7 +30,8 @@ import {
   type NonLiteralHttpServiceSchemaPath,
 } from 'zimic0';
 import {
-  createHttpInterceptor,
+  http,
+  type HttpNamespace,
   type HttpInterceptor,
   type LocalHttpInterceptor,
   type RemoteHttpInterceptor,
@@ -102,8 +103,9 @@ describe('Exports', () => {
     expectTypeOf<LiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<NonLiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
 
-    expectTypeOf(createHttpInterceptor).not.toBeAny();
-    expect(typeof createHttpInterceptor).toBe('function');
+    expectTypeOf(http.createInterceptor).not.toBeAny();
+    expect(typeof http.createInterceptor).toBe('function');
+    expectTypeOf<HttpNamespace>().not.toBeAny();
     expectTypeOf<HttpInterceptor<never>>().not.toBeAny();
     expectTypeOf<LocalHttpInterceptor<never>>().not.toBeAny();
     expectTypeOf<RemoteHttpInterceptor<never>>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, afterAll, expect, describe, it, expectTypeOf } from 'vitest';
 import { HttpRequest, HttpResponse, HttpSearchParams, JSONSerialized } from 'zimic0';
-import { HttpInterceptorType, createHttpInterceptor } from 'zimic0/interceptor';
+import { http, HttpInterceptorType } from 'zimic0/interceptor';
 
 import { getCrypto } from '@tests/utils/crypto';
 
@@ -36,12 +36,12 @@ async function getNotificationsBaseURL(type: HttpInterceptorType) {
 async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType) {
   const { platform, type, fetch } = options;
 
-  const authInterceptor = createHttpInterceptor<AuthServiceSchema>({
+  const authInterceptor = http.createInterceptor<AuthServiceSchema>({
     type,
     baseURL: await getAuthBaseURL(type),
   });
 
-  const notificationInterceptor = createHttpInterceptor<NotificationServiceSchema>({
+  const notificationInterceptor = http.createInterceptor<NotificationServiceSchema>({
     type,
     baseURL: await getNotificationsBaseURL(type),
   });

--- a/examples/with-jest-jsdom/tests/interceptors/github.ts
+++ b/examples/with-jest-jsdom/tests/interceptors/github.ts
@@ -1,8 +1,8 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import { GITHUB_API_BASE_URL, GitHubRepository } from '../../src/app';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/examples/with-jest-node/tests/interceptors/github.ts
+++ b/examples/with-jest-node/tests/interceptors/github.ts
@@ -1,8 +1,8 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import { GITHUB_API_BASE_URL, GitHubRepository } from '../../src/app';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/examples/with-next-js/tests/interceptors/github/interceptor.ts
+++ b/examples/with-next-js/tests/interceptors/github/interceptor.ts
@@ -1,9 +1,9 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import environment from '../../../src/config/environment';
 import { GitHubRepository } from '../../../src/services/github';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/examples/with-playwright/tests/interceptors/github/interceptor.ts
+++ b/examples/with-playwright/tests/interceptors/github/interceptor.ts
@@ -1,9 +1,9 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import environment from '../../../src/config/environment';
 import { GitHubRepository } from '../../../src/services/github';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/examples/with-vitest-browser/tests/interceptors/github.ts
+++ b/examples/with-vitest-browser/tests/interceptors/github.ts
@@ -1,8 +1,8 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import { GITHUB_API_BASE_URL, GitHubRepository } from '../../src/app';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/examples/with-vitest-jsdom/tests/interceptors/github.ts
+++ b/examples/with-vitest-jsdom/tests/interceptors/github.ts
@@ -1,8 +1,8 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import { GITHUB_API_BASE_URL, GitHubRepository } from '../../src/app';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/examples/with-vitest-node/tests/interceptors/github.ts
+++ b/examples/with-vitest-node/tests/interceptors/github.ts
@@ -1,8 +1,8 @@
-import { createHttpInterceptor } from 'zimic/interceptor';
+import { http } from 'zimic/interceptor';
 
 import { GITHUB_API_BASE_URL, GitHubRepository } from '../../src/app';
 
-const githubInterceptor = createHttpInterceptor<{
+const githubInterceptor = http.createInterceptor<{
   '/repos/:owner/:name': {
     GET: {
       response: {

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -1,5 +1,6 @@
 import NotStartedHttpInterceptorError from './http/interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatform from './http/interceptor/errors/UnknownHttpInterceptorPlatform';
+import { createHttpInterceptor } from './http/interceptor/factory';
 import UnregisteredServiceWorkerError from './http/interceptorWorker/errors/UnregisteredServiceWorkerError';
 
 export { UnknownHttpInterceptorPlatform, NotStartedHttpInterceptorError, UnregisteredServiceWorkerError };
@@ -31,4 +32,8 @@ export type { ExtractHttpInterceptorSchema } from './http/interceptor/types/sche
 
 export type { LocalHttpInterceptor, RemoteHttpInterceptor, HttpInterceptor } from './http/interceptor/types/public';
 
-export { createHttpInterceptor } from './http/interceptor/factory';
+export const http = {
+  createInterceptor: createHttpInterceptor,
+};
+
+export type HttpNamespace = typeof http;

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest';
 
 import { HttpServiceSchema } from '@/http/types/schema';
-import { createHttpInterceptor, HttpInterceptor } from '@/interceptor';
+import { http } from '@/interceptor';
 import HttpInterceptorStore from '@/interceptor/http/interceptor/HttpInterceptorStore';
 import LocalHttpInterceptor from '@/interceptor/http/interceptor/LocalHttpInterceptor';
 import RemoteHttpInterceptor from '@/interceptor/http/interceptor/RemoteHttpInterceptor';
@@ -11,6 +11,7 @@ import {
   LocalHttpInterceptorOptions,
   RemoteHttpInterceptorOptions,
 } from '@/interceptor/http/interceptor/types/options';
+import { HttpInterceptor } from '@/interceptor/http/interceptor/types/public';
 import { createHttpInterceptorWorker } from '@/interceptor/http/interceptorWorker/factory';
 import LocalHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker';
 import RemoteHttpInterceptorWorker from '@/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker';
@@ -60,7 +61,7 @@ export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(
   options: HttpInterceptorOptions,
 ): LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;
 export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(options: HttpInterceptorOptions) {
-  return createHttpInterceptor<Schema>(options) satisfies HttpInterceptor<Schema> as
+  return http.createInterceptor<Schema>(options) satisfies HttpInterceptor<Schema> as
     | LocalHttpInterceptor<Schema>
     | RemoteHttpInterceptor<Schema>;
 }


### PR DESCRIPTION
### Refactoring
- [#zimic] Grouped http exports into the namespace `http`. Thus, `createHttpInterceptor` can now be accessed by `http.createInterceptor`.

```ts
import { http } from 'zimic/interceptor';

const authInterceptor = http.createInterceptor<AuthServiceSchema>({
  type: 'local',
  baseURL: await getAuthBaseURL(type),
});

const notificationInterceptor = http.createInterceptor<NotificationServiceSchema>({
  type: 'remote',
  baseURL: await getNotificationsBaseURL(type),
});
```

Closes #147.