### PR TITLE
fix: clear exit listeners on server cli exit

### DIFF
--- a/packages/zimic/src/cli/server/start.ts
+++ b/packages/zimic/src/cli/server/start.ts
@@ -37,6 +37,10 @@ async function startInterceptorServer({ hostname, port, ephemeral, onReady }: Se
   if (ephemeral) {
     await server.stop();
   }
+
+  for (const exitEvent of PROCESS_EXIT_EVENTS) {
+    process.removeAllListeners(exitEvent);
+  }
 }
 
 export default startInterceptorServer;


### PR DESCRIPTION
### Fixes
- [#zimic] Cleared exit event listeners when the interceptor server CLI exits.
