### PR TITLE
fix: strict CLI (#156)

### DIFF
--- a/packages/zimic/src/cli/__tests__/cli.node.test.ts
+++ b/packages/zimic/src/cli/__tests__/cli.node.test.ts
@@ -40,6 +40,19 @@ describe('CLI', () => {
     });
   });
 
+  it('should throw an error if an unknown command is provided', async () => {
+    const unknownCommand = 'unknown';
+
+    processArgvSpy.mockReturnValue(['node', 'cli.js', unknownCommand]);
+
+    await usingIgnoredConsole(['error'], async (spies) => {
+      await expect(runCLI()).rejects.toThrowError('process.exit unexpectedly called with "1"');
+
+      expect(spies.error).toHaveBeenCalledTimes(1);
+      expect(spies.error).toHaveBeenCalledWith(`Unknown argument: ${unknownCommand}`);
+    });
+  });
+
   it('should show a help message', async () => {
     processArgvSpy.mockReturnValue(['node', 'cli.js', '--help']);
     await usingIgnoredConsole(['log'], async (spies) => {

--- a/packages/zimic/src/cli/cli.ts
+++ b/packages/zimic/src/cli/cli.ts
@@ -12,6 +12,7 @@ async function runCLI() {
     .version(version)
     .showHelpOnFail(false)
     .demandCommand()
+    .strict()
 
     .command('browser', 'Browser', (yargs) =>
       yargs.demandCommand().command(


### PR DESCRIPTION
### Fixes
- [#zimic] Added `.strict()` to the CLI declaration, making sure that unknown commands are reported as errors instead of being silently ignored.

Closes #156.