### PR TITLE
docs: fix relative paths in published `README.md`

### DIFF
--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -72,7 +72,7 @@
     "deps:install-playwright": "pnpm playwright install chromium",
     "deps:init-msw": "msw init ./public --no-save",
     "postinstall": "node -e \"try{require('./dist/scripts/postinstall.js')}catch(error){console.error(error)}\"",
-    "prepublish:adapt-relative-paths": "sed -E -i 's/\\]\\(\\.\\/(.+)\\)/](..\\/..\\/\\1)/g'",
+    "prepublish:adapt-relative-paths": "sed -E -i 's/\\]\\(\\.\\/([^\\)]+)\\)/](..\\/..\\/\\1)/g;s/\"\\.\\/([^\"]+)\"/\"..\\/..\\/\\1\"/g'",
     "prepublishOnly": "cp ../../README.md ../../LICENSE.md . && pnpm prepublish:adapt-relative-paths README.md"
   },
   "dependencies": {


### PR DESCRIPTION
### Documentation
- [#zimic] Correctly adapt relative paths in `img` tags in `README.md`.
