### PR TITLE
docs: `v0.5`

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  TURBO_LOG_ORDER: stream
   TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_REMOTE_CACHE_TEAM }}
-  TURBO_LOG_ORDER: stream
 
 jobs:
   cache-canary:
@@ -26,6 +26,7 @@ jobs:
         node-version:
           - 18
           - 20
+          - 22
 
     env:
       NODE_VERSION: ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -572,10 +572,18 @@ const baseURL = interceptor.baseURL();
 
 ##### Unhandled requests
 
-When a request is not matched by any interceptors, it is considered unhandled and will be logged to the console by
-default. In a [local interceptor](#local-http-interceptors), unhandled requests are always bypassed, meaning that they
-pass through the interceptor and reach the real network. [Remote interceptors](#remote-http-interceptors) in pair with
-an [interceptor server](#zimic-server) always reject unhandled requests because they cannot be bypassed.
+When a request is not matched by any interceptor handlers, it is considered unhandled and will be logged to the console
+by default.
+
+> [!TIP]
+>
+> If you expected a request to be handled, but it was not, make sure that the interceptor
+> [base URL](#httpcreateinterceptor), [path](#http-interceptormethodpath), [method](#http-interceptormethodpath), and
+> [restrictions](#http-handlerwithrestriction) correctly match the request.
+
+In a [local interceptor](#local-http-interceptors), unhandled requests are always bypassed, meaning that they pass
+through the interceptor and reach the real network. [Remote interceptors](#remote-http-interceptors) in pair with an
+[interceptor server](#zimic-server) always reject unhandled requests because they cannot be bypassed.
 
 You can override the default logging behavior per interceptor with `onUnhandledRequest` in `http.createInterceptor`.
 

--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -119,9 +119,7 @@ describe('Exports', () => {
     expectTypeOf(http.createInterceptor).toEqualTypeOf<HttpInterceptorNamespace['createInterceptor']>();
     expect(typeof http.createInterceptor).toBe('function');
 
-    expectTypeOf(http.default.onUnhandledRequest).toEqualTypeOf<
-      HttpInterceptorNamespace['default']['onUnhandledRequest']
-    >();
+    expectTypeOf(http.default).toEqualTypeOf<Readonly<HttpInterceptorNamespace['default']>>();
     expect(typeof http.default.onUnhandledRequest).toBe('function');
 
     expectTypeOf<UnhandledRequestStrategy>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -32,7 +32,8 @@ import {
 } from 'zimic0';
 import {
   http,
-  type HttpNamespace,
+  type HttpInterceptorNamespace,
+  type HttpInterceptorNamespaceDefault,
   type HttpInterceptor,
   type LocalHttpInterceptor,
   type RemoteHttpInterceptor,
@@ -112,12 +113,17 @@ describe('Exports', () => {
     expectTypeOf<NonLiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<PathParamsSchemaFromPath<never>>().not.toBeAny();
 
-    expectTypeOf(http.createInterceptor).not.toBeAny();
-    expect(typeof http.createInterceptor).toBe('function');
-    expectTypeOf<HttpNamespace>().not.toBeAny();
+    expectTypeOf<HttpInterceptorNamespace>().not.toBeAny();
+    expectTypeOf<HttpInterceptorNamespaceDefault>().not.toBeAny();
 
-    expectTypeOf(http.default.onUnhandledRequest).not.toBeAny();
+    expectTypeOf(http.createInterceptor).toEqualTypeOf<HttpInterceptorNamespace['createInterceptor']>();
+    expect(typeof http.createInterceptor).toBe('function');
+
+    expectTypeOf(http.default.onUnhandledRequest).toEqualTypeOf<
+      HttpInterceptorNamespace['default']['onUnhandledRequest']
+    >();
     expect(typeof http.default.onUnhandledRequest).toBe('function');
+
     expectTypeOf<UnhandledRequestStrategy>().not.toBeAny();
     expectTypeOf<UnhandledRequestStrategy.Action>().not.toBeAny();
     expectTypeOf<UnhandledRequestStrategy.Declaration>().not.toBeAny();

--- a/examples/with-next-js/.gitignore
+++ b/examples/with-next-js/.gitignore
@@ -4,6 +4,7 @@
 # Testing
 /tests/outputs
 /tests/reports
+/public/mockServiceWorker.js
 
 # Next.js
 /.next

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -11,14 +11,22 @@ export const HTTP_METHODS = Object.freeze(['GET', 'POST', 'PUT', 'PATCH', 'DELET
  */
 export type HttpMethod = (typeof HTTP_METHODS)[number];
 
-/** A schema representing the structure of an HTTP request. */
+/**
+ * A schema representing the structure of an HTTP request.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export interface HttpServiceRequestSchema {
   headers?: HttpHeadersSchema;
   searchParams?: HttpSearchParamsSchema;
   body?: HttpBody;
 }
 
-/** A schema representing the structure of an HTTP response. */
+/**
+ * A schema representing the structure of an HTTP response.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export interface HttpServiceResponseSchema {
   headers?: HttpHeadersSchema;
   body?: HttpBody;
@@ -30,7 +38,11 @@ export namespace HttpServiceResponseSchema {
   }
 }
 
-/** A schema representing the structure of HTTP responses by status code. */
+/**
+ * A schema representing the structure of HTTP responses by status code.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export type HttpServiceResponseSchemaByStatusCode = {
   [statusCode: number]: HttpServiceResponseSchema;
 } & {
@@ -44,12 +56,20 @@ export namespace HttpServiceResponseSchemaByStatusCode {
   };
 }
 
-/** Extracts the status codes used in a response schema by status code. */
+/**
+ * Extracts the status codes used in a response schema by status code.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export type HttpServiceResponseSchemaStatusCode<
   ResponseSchemaByStatusCode extends HttpServiceResponseSchemaByStatusCode,
 > = Extract<keyof ResponseSchemaByStatusCode, number>;
 
-/** A schema representing the structure of an HTTP request and response for a given method. */
+/**
+ * A schema representing the structure of an HTTP request and response for a given method.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export interface HttpServiceMethodSchema {
   request?: HttpServiceRequestSchema;
   response?: HttpServiceResponseSchemaByStatusCode;
@@ -65,7 +85,11 @@ export namespace HttpServiceMethodSchema {
   }
 }
 
-/** A schema representing the structure of HTTP request and response by method. */
+/**
+ * A schema representing the structure of HTTP request and response by method.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export interface HttpServiceMethodsSchema {
   GET?: HttpServiceMethodSchema.NoRequestBody;
   POST?: HttpServiceMethodSchema;
@@ -76,12 +100,20 @@ export interface HttpServiceMethodsSchema {
   OPTIONS?: HttpServiceMethodSchema.NoRequestBody;
 }
 
-/** A schema representing the structure of paths, methods, requests, and responses for an HTTP service. */
+/**
+ * A schema representing the structure of paths, methods, requests, and responses for an HTTP service.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export interface HttpServiceSchema {
   [path: string]: HttpServiceMethodsSchema;
 }
 
-/** A namespace containing utility types for validating HTTP type schemas. */
+/**
+ * A namespace containing utility types for validating HTTP type schemas.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export namespace HttpSchema {
   /** Validates that a type is a valid HTTP service schema. */
   export type Paths<Schema extends HttpServiceSchema> = Schema;

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -133,7 +133,11 @@ export namespace HttpSchema {
   export type SearchParams<Schema extends HttpSearchParamsSchema> = Schema;
 }
 
-/** Extracts the methods from an HTTP service schema. */
+/**
+ * Extracts the methods from an HTTP service schema.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
   Schema,
   any, // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -143,13 +147,19 @@ export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
 /**
  * Extracts the literal paths from an HTTP service schema containing certain methods. Only the methods defined in the
  * schema are allowed.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type LiteralHttpServiceSchemaPath<
   Schema extends HttpServiceSchema,
   Method extends HttpServiceSchemaMethod<Schema>,
 > = LooseLiteralHttpServiceSchemaPath<Schema, Method>;
 
-/** Extracts the literal paths from an HTTP service schema containing certain methods. Any method is allowed. */
+/**
+ * Extracts the literal paths from an HTTP service schema containing certain methods. Any method is allowed.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export type LooseLiteralHttpServiceSchemaPath<Schema extends HttpServiceSchema, Method extends HttpMethod> = {
   [Path in Extract<keyof Schema, string>]: Method extends keyof Schema[Path] ? Path : never;
 }[Extract<keyof Schema, string>];
@@ -160,7 +170,11 @@ type AllowAnyStringInPathParams<Path extends string> = Path extends `${infer Pre
     ? `${Prefix}${string}`
     : Path;
 
-/** Extracts the non-literal paths from an HTTP service schema containing certain methods. */
+/**
+ * Extracts the non-literal paths from an HTTP service schema containing certain methods.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export type NonLiteralHttpServiceSchemaPath<
   Schema extends HttpServiceSchema,
   Method extends HttpServiceSchemaMethod<Schema>,
@@ -199,7 +213,11 @@ export type InferLiteralHttpServiceSchemaPath<
     : never
 >;
 
-/** Extracts the paths from an HTTP service schema containing certain methods. */
+/**
+ * Extracts the paths from an HTTP service schema containing certain methods.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ */
 export type HttpServiceSchemaPath<Schema extends HttpServiceSchema, Method extends HttpServiceSchemaMethod<Schema>> =
   | LiteralHttpServiceSchemaPath<Schema, Method>
   | NonLiteralHttpServiceSchemaPath<Schema, Method>;
@@ -211,4 +229,10 @@ type RecursivePathParamsSchemaFromPath<Path extends string> =
       ? { [Name in ParamName]: string }
       : {};
 
+/**
+ * Infers the path parameters schema from a path string.
+ *
+ * @example
+ *   '/users/:userId/notifications' -> { userId: string }
+ */
 export type PathParamsSchemaFromPath<Path extends string> = Prettify<RecursivePathParamsSchemaFromPath<Path>>;

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -15,20 +15,57 @@ export type HttpInterceptorType = 'local' | 'remote';
  */
 export type HttpInterceptorPlatform = 'node' | 'browser';
 
-/** The strategy to handle unhandled requests. */
+/**
+ * The strategy to treat unhandled requests.
+ *
+ * When `log` is `true`, unhandled requests are logged to the terminal. If provided a handler, unhandled requests will
+ * be logged if `await context.log()` is called.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+ */
 export namespace UnhandledRequestStrategy {
-  /** A static declaration of the strategy to handle unhandled requests. */
+  /**
+   * A static declaration of the strategy to handle unhandled requests.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+   */
   export type Declaration = Partial<{
     log: boolean;
   }>;
 
   export interface HandlerContext {
+    /**
+     * Logs the unhandled request to the terminal.
+     *
+     * If the request was bypassed by a
+     * {@link https://github.com/diego-aquino/zimic#local-http-interceptors local interceptor}, the log will be a
+     * warning. If the request was rejected by a
+     * {@link https://github.com/diego-aquino/zimic#local-http-interceptors remote interceptor}, the log will be an
+     * error.
+     *
+     * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+     */
     log: () => Promise<void>;
   }
-  /** A dynamic handler to unhandled requests. */
+
+  /**
+   * A dynamic handler to unhandled requests.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+   */
   export type Handler = (request: HttpRequest, context: HandlerContext) => PossiblePromise<void>;
 
-  /** The action to take when an unhandled request is intercepted. */
+  /**
+   * The action to take when an unhandled request is intercepted.
+   *
+   * In a {@link https://github.com/diego-aquino/zimic#local-http-interceptors local interceptor}, the action is always
+   * `bypass`, meaning that unhandled requests pass through the interceptor and reach the real network.
+   * {@link https://github.com/diego-aquino/zimic#local-http-interceptors Remote interceptors} always use `reject`, since
+   * unhandled requests that react an {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}
+   * cannot be bypassed.
+   *
+   * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+   */
   export type Action = 'bypass' | 'reject';
 }
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -56,18 +93,21 @@ export interface SharedHttpInterceptorOptions {
   onUnhandledRequest?: UnhandledRequestStrategy;
 }
 
-/** The options to create a local HTTP interceptor. */
+/** The options to create a {@link https://github.com/diego-aquino/zimic#local-http-interceptors local HTTP interceptor}. */
 export interface LocalHttpInterceptorOptions extends SharedHttpInterceptorOptions {
   type: 'local';
 }
 
-/** The options to create a remote HTTP interceptor. */
+/**
+ * The options to create a
+ * {@link https://github.com/diego-aquino/zimic#remote-http-interceptors remote HTTP interceptor}.
+ */
 export interface RemoteHttpInterceptorOptions extends SharedHttpInterceptorOptions {
   type: 'remote';
 }
 
 /**
- * The options to create an HTTP interceptor.
+ * The options to create an {@link https://github.com/diego-aquino/zimic#httpinterceptor HTTP interceptor}.
  *
  * @see {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor()` API reference}
  */

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -18,8 +18,8 @@ export type HttpInterceptorPlatform = 'node' | 'browser';
 /**
  * The strategy to treat unhandled requests.
  *
- * When `log` is `true`, unhandled requests are logged to the terminal. If provided a handler, unhandled requests will
- * be logged if `await context.log()` is called.
+ * When `log` is `true`, unhandled requests are logged to the console. If provided a handler, unhandled requests will be
+ * logged if `await context.log()` is called.
  *
  * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
  */
@@ -35,7 +35,7 @@ export namespace UnhandledRequestStrategy {
 
   export interface HandlerContext {
     /**
-     * Logs the unhandled request to the terminal.
+     * Logs the unhandled request to the console.
      *
      * If the request was bypassed by a
      * {@link https://github.com/diego-aquino/zimic#local-http-interceptors local interceptor}, the log will be a

--- a/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
+++ b/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
@@ -1,0 +1,23 @@
+import { createHttpInterceptor } from '../interceptor/factory';
+import { UnhandledRequestStrategy } from '../interceptor/types/options';
+import HttpInterceptorWorkerStore from '../interceptorWorker/HttpInterceptorWorkerStore';
+import {
+  HttpInterceptorNamespace as PublicHttpInterceptorNamespace,
+  HttpInterceptorNamespaceDefault as PublicHttpInterceptorNamespaceDefault,
+} from './types';
+
+export class HttpInterceptorNamespaceDefault implements PublicHttpInterceptorNamespaceDefault {
+  private store = new HttpInterceptorWorkerStore();
+
+  onUnhandledRequest(strategy: UnhandledRequestStrategy) {
+    this.store.setDefaultUnhandledRequestStrategy(strategy);
+  }
+}
+
+class HttpInterceptorNamespace implements PublicHttpInterceptorNamespace {
+  createInterceptor = createHttpInterceptor;
+
+  default = Object.freeze(new HttpInterceptorNamespaceDefault());
+}
+
+export default HttpInterceptorNamespace;

--- a/packages/zimic/src/interceptor/http/namespace/types.ts
+++ b/packages/zimic/src/interceptor/http/namespace/types.ts
@@ -1,0 +1,36 @@
+import { createHttpInterceptor } from '../interceptor/factory';
+import { UnhandledRequestStrategy } from '../interceptor/types/options';
+
+export interface HttpInterceptorNamespaceDefault {
+  /**
+   * Sets the default strategy for unhandled requests. If a request does not start with the base URL of any
+   * interceptors, this strategy will be used. If a function is provided, it will be called with the unhandled request.
+   * You can override this default for specific interceptors by using `onUnhandledRequest` in
+   * {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor`}.
+   *
+   * @param strategy The default strategy to be set.
+   */
+  onUnhandledRequest: (strategy: UnhandledRequestStrategy) => void;
+}
+
+/**
+ * A set of interceptor resources for mocking HTTP requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#zimicinterceptor-api-reference `zimic/interceptor` API reference}
+ */
+export interface HttpInterceptorNamespace {
+  /**
+   * Creates an HTTP interceptor.
+   *
+   * @param options The options for the interceptor.
+   * @returns The created HTTP interceptor.
+   * @throws {InvalidURLError} If the base URL is invalid.
+   * @throws {UnsupportedURLProtocolError} If the base URL protocol is not either `http` or `https`.
+   * @see {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor` API reference}
+   * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring service schemas}
+   */
+  createInterceptor: typeof createHttpInterceptor;
+
+  /** Default settings. */
+  default: HttpInterceptorNamespaceDefault;
+}

--- a/packages/zimic/src/interceptor/http/namespace/types.ts
+++ b/packages/zimic/src/interceptor/http/namespace/types.ts
@@ -1,6 +1,7 @@
 import { createHttpInterceptor } from '../interceptor/factory';
 import { UnhandledRequestStrategy } from '../interceptor/types/options';
 
+/** Default HTTP interceptor settings. */
 export interface HttpInterceptorNamespaceDefault {
   /**
    * Sets the default strategy for unhandled requests. If a request does not start with the base URL of any
@@ -31,6 +32,6 @@ export interface HttpInterceptorNamespace {
    */
   createInterceptor: typeof createHttpInterceptor;
 
-  /** Default settings. */
+  /** Default HTTP interceptor settings. */
   default: HttpInterceptorNamespaceDefault;
 }

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -125,7 +125,7 @@ export interface HttpRequestHandler<
   /**
    * Declares a restriction to intercepted request matches. `headers`, `searchParams`, and `body` are supported to limit
    * which requests will match the handler and receive the mock response. If multiple restrictions are declared, either
-   * in a single object or with multiple calls to `.with()`, all of them must be met, essentially creating an AND
+   * in a single object or with multiple calls to `handler.with()`, all of them must be met, essentially creating an AND
    * condition.
    *
    * By default, restrictions use `exact: false`, meaning that any request **containing** the declared restrictions will
@@ -162,9 +162,9 @@ export interface HttpRequestHandler<
 
   /**
    * Clears any response declared with
-   * [`.respond(declaration)`](https://github.com/diego-aquino/zimic#http-handlerresponddeclaration), making the handler
-   * stop matching requests. The next handler, created before this one, that matches the same method and path will be
-   * used if present. If not, the requests of the method and path will not be intercepted.
+   * [`handler.respond(declaration)`](https://github.com/diego-aquino/zimic#http-handlerresponddeclaration), making the
+   * handler stop matching requests. The next handler, created before this one, that matches the same method and path
+   * will be used if present. If not, the requests of the method and path will not be intercepted.
    *
    * To make the handler match requests again, register a new response with
    * {@link https://github.com/diego-aquino/zimic#http-handlerrespond `handler.respond()`}.
@@ -180,11 +180,11 @@ export interface HttpRequestHandler<
 
   /**
    * Clears any response declared with
-   * [`.respond(declaration)`](https://github.com/diego-aquino/zimic#http-handlerresponddeclaration), restrictions
-   * declared with [`.with(restriction)`](https://github.com/diego-aquino/zimic#http-handlerwithrestriction), and
-   * intercepted requests, making the handler stop matching requests. The next handler, created before this one, that
-   * matches the same method and path will be used if present. If not, the requests of the method and path will not be
-   * intercepted.
+   * [`handler.respond(declaration)`](https://github.com/diego-aquino/zimic#http-handlerresponddeclaration),
+   * restrictions declared with
+   * [`handler.with(restriction)`](https://github.com/diego-aquino/zimic#http-handlerwithrestriction), and intercepted
+   * requests, making the handler stop matching requests. The next handler, created before this one, that matches the
+   * same method and path will be used if present. If not, the requests of the method and path will not be intercepted.
    *
    * To make the handler match requests again, register a new response with
    * {@link https://github.com/diego-aquino/zimic#http-handlerrespond `handler.respond()`}.

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -18,6 +18,11 @@ import {
   HttpRequestBodySchema,
 } from './requests';
 
+/**
+ * A static headers restriction to match intercepted requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ */
 export type HttpRequestHandlerHeadersStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
@@ -26,6 +31,11 @@ export type HttpRequestHandlerHeadersStaticRestriction<
   | HttpRequestHeadersSchema<Default<Schema[Path][Method]>>
   | HttpHeaders<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
 
+/**
+ * A static search params restriction to match intercepted requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ */
 export type HttpRequestHandlerSearchParamsStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
@@ -34,12 +44,22 @@ export type HttpRequestHandlerSearchParamsStaticRestriction<
   | HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>
   | HttpSearchParams<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
 
+/**
+ * A static body restriction to match intercepted requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ */
 export type HttpRequestHandlerBodyStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
 > = HttpRequestBodySchema<Default<Schema[Path][Method]>>;
 
+/**
+ * A static restriction to match intercepted requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ */
 export interface HttpRequestHandlerStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
@@ -51,12 +71,22 @@ export interface HttpRequestHandlerStaticRestriction<
   exact?: boolean;
 }
 
+/**
+ * A computed restriction to match intercepted requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ */
 export type HttpRequestHandlerComputedRestriction<
   Schema extends HttpServiceSchema,
   Method extends HttpServiceSchemaMethod<Schema>,
   Path extends HttpServiceSchemaPath<Schema, Method>,
 > = (request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) => boolean;
 
+/**
+ * A restriction to match intercepted requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ */
 export type HttpRequestHandlerRestriction<
   Schema extends HttpServiceSchema,
   Method extends HttpServiceSchemaMethod<Schema>,

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -54,13 +54,21 @@ export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> 
   null
 >;
 
-/** A strict representation of an intercepted HTTP request. The body and search params are already parsed by default. */
+/**
+ * A strict representation of an intercepted HTTP request. The body, search params and path params are already parsed by
+ * default.
+ */
 export interface HttpInterceptorRequest<Path extends string, MethodSchema extends HttpServiceMethodSchema>
   extends Omit<HttpRequest, keyof Body | 'headers'> {
+  /** The headers of the request. */
   headers: HttpHeaders<HttpRequestHeadersSchema<MethodSchema>>;
+  /** The path parameters of the request. They are parsed from the path string when using dynamic paths. */
   pathParams: PathParamsSchemaFromPath<Path>;
+  /** The search parameters of the request. */
   searchParams: HttpSearchParams<HttpRequestSearchParamsSchema<MethodSchema>>;
+  /** The body of the request. It is already parsed by default. */
   body: HttpRequestBodySchema<MethodSchema>;
+  /** The raw request object. */
   raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;
 }
 
@@ -74,14 +82,21 @@ export type HttpResponseBodySchema<
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > = Default<Default<MethodSchema['response']>[StatusCode]['body'], null>;
 
-/** A strict representation of an intercepted HTTP response. The body and search params are already parsed by default. */
+/**
+ * A strict representation of an intercepted HTTP response. The body, search params and path params are already parsed
+ * by default.
+ */
 export interface HttpInterceptorResponse<
   MethodSchema extends HttpServiceMethodSchema,
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > extends Omit<HttpResponse, keyof Body | 'headers'> {
+  /** The headers of the response. */
   headers: HttpHeaders<HttpResponseHeadersSchema<MethodSchema, StatusCode>>;
+  /** The status code of the response. */
   status: StatusCode;
+  /** The body of the response. It is already parsed by default. */
   body: HttpResponseBodySchema<MethodSchema, StatusCode>;
+  /** The raw response object. */
   raw: HttpResponse<HttpResponseBodySchema<MethodSchema, StatusCode>, StatusCode>;
 }
 
@@ -97,13 +112,14 @@ export const HTTP_INTERCEPTOR_RESPONSE_HIDDEN_BODY_PROPERTIES = Object.freeze(
 );
 
 /**
- * A strict representation of a tracked, intercepted HTTP request, along with its response. The body and search params
- * are already parsed by default.
+ * A strict representation of a tracked, intercepted HTTP request, along with its response. The body, search params and
+ * path params are already parsed by default.
  */
 export interface TrackedHttpInterceptorRequest<
   Path extends string,
   MethodSchema extends HttpServiceMethodSchema,
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>> = never,
 > extends HttpInterceptorRequest<Path, MethodSchema> {
+  /** The response that was returned for the intercepted request. */
   response: StatusCode extends [never] ? never : HttpInterceptorResponse<MethodSchema, StatusCode>;
 }

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -1,9 +1,7 @@
 import NotStartedHttpInterceptorError from './http/interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatform from './http/interceptor/errors/UnknownHttpInterceptorPlatform';
-import { createHttpInterceptor } from './http/interceptor/factory';
-import { UnhandledRequestStrategy } from './http/interceptor/types/options';
 import UnregisteredServiceWorkerError from './http/interceptorWorker/errors/UnregisteredServiceWorkerError';
-import HttpInterceptorWorkerStore from './http/interceptorWorker/HttpInterceptorWorkerStore';
+import HttpInterceptorNamespace from './http/namespace/HttpInterceptorNamespace';
 
 export { UnknownHttpInterceptorPlatform, NotStartedHttpInterceptorError, UnregisteredServiceWorkerError };
 
@@ -22,10 +20,10 @@ export type {
   PendingRemoteHttpRequestHandler,
   HttpRequestHandler,
   HttpRequestHandlerRestriction,
+  HttpRequestHandlerStaticRestriction,
   HttpRequestHandlerComputedRestriction,
   HttpRequestHandlerHeadersStaticRestriction,
   HttpRequestHandlerSearchParamsStaticRestriction,
-  HttpRequestHandlerStaticRestriction,
   HttpRequestHandlerBodyStaticRestriction,
 } from './http/requestHandler/types/public';
 
@@ -41,42 +39,11 @@ export type { ExtractHttpInterceptorSchema } from './http/interceptor/types/sche
 
 export type { LocalHttpInterceptor, RemoteHttpInterceptor, HttpInterceptor } from './http/interceptor/types/public';
 
-/** @see {@link https://github.com/diego-aquino/zimic#http `http` API reference} */
-export interface HttpNamespace {
-  /**
-   * Creates an HTTP interceptor.
-   *
-   * @param options The options for the interceptor.
-   * @returns The created HTTP interceptor.
-   * @throws {InvalidURLError} If the base URL is invalid.
-   * @throws {UnsupportedURLProtocolError} If the base URL protocol is not either `http` or `https`.
-   * @see {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor` API reference}
-   * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring service schemas}
-   */
-  createInterceptor: typeof createHttpInterceptor;
+export type { HttpInterceptorNamespace, HttpInterceptorNamespaceDefault } from './http/namespace/types';
 
-  /** Default HTTP settings. */
-  default: {
-    /**
-     * Sets the default strategy for unhandled requests. If a request does not start with the base URL of any
-     * interceptors, this strategy will be used. If a function is provided, it will be called with the unhandled
-     * request. Defining a custom strategy when creating an interceptor will override this default for that
-     * interceptor.
-     *
-     * @param strategy The default strategy to be set.
-     */
-    onUnhandledRequest: (strategy: UnhandledRequestStrategy) => void;
-  };
-}
-
-/** @see {@link https://github.com/diego-aquino/zimic#http `http` API reference} */
-export const http: HttpNamespace = Object.freeze({
-  createInterceptor: createHttpInterceptor,
-
-  default: Object.freeze({
-    onUnhandledRequest: (strategy: UnhandledRequestStrategy) => {
-      const store = new HttpInterceptorWorkerStore();
-      store.setDefaultUnhandledRequestStrategy(strategy);
-    },
-  }),
-});
+/**
+ * A set of interceptor resources for mocking HTTP requests.
+ *
+ * @see {@link https://github.com/diego-aquino/zimic#zimicinterceptor-api-reference `zimic/interceptor` API reference}
+ */
+export const http = Object.freeze(new HttpInterceptorNamespace());


### PR DESCRIPTION
### Refactoring
- [#zimic] Improved the internal structure of the HTTP namespace.

### Documentation
- [#zimic] Documented the new unhandled request API and inferred path parameters.

Closes #26.
