### PR TITLE
fix: improve unhandled request logs (#164)

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/utils.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/utils.ts
@@ -39,15 +39,17 @@ export async function verifyUnhandledRequestMessage(
 
   expect(message).toContain(
     platform === 'node'
-      ? `Search params: ${formatObjectToLog(Object.fromEntries(request.searchParams))}\n`
+      ? `Search params: ${formatObjectToLog(Object.fromEntries(request.searchParams))}`
       : 'Search params: [object Object]',
   );
 
   const body: unknown = request.body;
 
-  expect(message).toContain(
-    platform === 'node' || typeof body !== 'object' || body === null
-      ? `Body: ${formatObjectToLog(body)}\n`
-      : 'Body: [object Object]',
-  );
+  if (body === null) {
+    expect(message).toContain(platform === 'node' ? `Body: ${formatObjectToLog(body)}` : 'Body: ');
+  } else {
+    expect(message).toContain(
+      platform === 'node' || typeof body !== 'object' ? `Body: ${formatObjectToLog(body)}` : 'Body: [object Object]',
+    );
+  }
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -316,16 +316,15 @@ abstract class HttpInterceptorWorker {
     logWithPrefix(
       [
         `${action === 'bypass' ? 'Warning:' : 'Error:'} Request did not match any handlers and was ` +
-          `${action === 'bypass' ? chalk.yellow('bypassed') : chalk.red('rejected')}:\n\n `,
-        `${request.method} ${request.url}\n`,
-        '   Headers:',
-        `${formatObjectToLog(Object.fromEntries(request.headers))}\n`,
-        '   Search params:',
-        `${formatObjectToLog(Object.fromEntries(request.searchParams))}\n`,
-        '   Body:',
-        `${formatObjectToLog(request.body)}\n\n`,
-        'To handle this request, use an interceptor to create a handler for it.\n',
-        'If you are using restrictions, make sure that they match the content of the request.',
+          `${action === 'bypass' ? chalk.yellow('bypassed') : chalk.red('rejected')}.\n\n `,
+        `${request.method} ${request.url}`,
+        '\n    Headers:',
+        formatObjectToLog(Object.fromEntries(request.headers)),
+        '\n    Search params:',
+        formatObjectToLog(Object.fromEntries(request.searchParams)),
+        '\n    Body:',
+        formatObjectToLog(request.body),
+        '\n\nLearn more about unhandled requests: https://github.com/diego-aquino/zimic#unhandled-requests',
       ],
       { method: action === 'bypass' ? 'warn' : 'error' },
     );


### PR DESCRIPTION
### Fixes
- [#zimic] Prevented `[object Object]` in browser logs about unhandled requests. Also improved the log messages:

  - Terminal bypassed:
    ```
    [zimic] Warning: Request did not match any handlers and was bypassed.

      OPTIONS http://localhost:3000/filters
        Headers: {}
        Search params: {}
        Body: null

    Learn more about unhandled requests: https://github.com/diego-aquino/zimic#unhandled-requests
    ```

  - Terminal rejected:
    ```
    [zimic] Error: Request did not match any handlers and was rejected.

      OPTIONS http://localhost:43569/path-c606ce6d-bd38-4d70-a49e-0176e59bab4b/filters
        Headers: { 'accept-encoding': 'gzip, deflate', 'accept-language': '*', 'content-type': ... }
        Search params: {}
        Body: null

    Learn more about unhandled requests: https://github.com/diego-aquino/zimic#unhandled-requests
    ```

  - Browser bypassed
    ![image](https://github.com/diego-aquino/zimic/assets/58959382/8b33b025-f2d4-4847-8ae5-6f706a8cfd87)


Closes #164.